### PR TITLE
Bug 1803 RESERVIERE ALLES tut nichts

### DIFF
--- a/src/laws.c
+++ b/src/laws.c
@@ -4127,7 +4127,7 @@ int pay_cmd(unit * u, struct order *ord)
 static int reserve_i(unit * u, struct order *ord, int flags)
 {
     if (u->number > 0 && (urace(u)->ec_flags & GETITEM)) {
-        int use, count;
+        int use, count, para;
         const resource_type *rtype;
         const char *s;
 
@@ -4135,16 +4135,20 @@ static int reserve_i(unit * u, struct order *ord, int flags)
         skip_token();
         s = getstrtoken();
         count = atoip((const char *)s);
+		para = findparam(s, u->faction->locale);
 
-        if (count == 0 && findparam(s, u->faction->locale) == P_EACH) {
+        if (count == 0 && para == P_EACH) {
             count = getint() * u->number;
         }
-
         rtype = findresourcetype(getstrtoken(), u->faction->locale);
         if (rtype == NULL)
             return 0;
 
         set_resvalue(u, rtype, 0);      /* make sure the pool is empty */
+
+		if (count == 0 && para == P_ANY) {
+			count = get_resource(u, rtype);
+		}
         use = use_pooled(u, rtype, flags, count);
         if (use) {
             set_resvalue(u, rtype, use);
@@ -4619,6 +4623,10 @@ void init_processor(void)
 
     p += 10;                      /* can't allow reserve before siege (weapons) */
     add_proc_region(p, &enter_1, "Betreten (2. Versuch)");
+	if (get_param_int(global.parameters, "rules.reserve.twophase", 0)) {
+		add_proc_order(p, K_RESERVE, &reserve_self, 0, "Selbst_Reservieren");
+		p += 10;
+	}
     add_proc_order(p, K_RESERVE, &reserve_cmd, 0, "Reservieren");
     add_proc_order(p, K_CLAIM, &claim_cmd, 0, NULL);
     add_proc_unit(p, &follow_unit, "Folge auf Einheiten setzen");


### PR DESCRIPTION
Reserviere Alles implementiert.
Option für rules.reserve.twophase in die Befehlsabarbeitung
implementiert.
