### PR TITLE
Bug 1938 [E3] Magiepatzer kaputt (auraverlust statt kostensteigerung)!

### DIFF
--- a/src/kernel/magic.c
+++ b/src/kernel/magic.c
@@ -2843,11 +2843,11 @@ void magic(void)
         }
       }
       /* erst bezahlen, dann Kostenzähler erhöhen */
-      if (fumbled) {
+	  if (co->level>0) {
+		  pay_spell(u, sp, co->level, co->distance);
+	  }
+	  if (fumbled) {
         do_fumble(co);
-      }
-      if (co->level>0) {
-        pay_spell(u, sp, co->level, co->distance);
       }
       countspells(u, 1);
     }


### PR DESCRIPTION
Erst Bezahlen, dann Patzer. Sonst werden die Kosten im Falle des
"kleinsten" Patzers noch beim aktuellen Spruch erhöht.
