### PR TITLE
Piraterie repariert

### DIFF
--- a/src/kernel/move.c
+++ b/src/kernel/move.c
@@ -2314,7 +2314,7 @@ static void piracy_cmd(unit * u, struct order *ord)
     if (saff != 0) {
       saff = rng_int() % saff;
       for (dir = 0; dir != MAXDIRECTIONS; ++dir) {
-        if (saff != aff[dir].value)
+        if (saff < aff[dir].value)
           break;
         saff -= aff[dir].value;
       }


### PR DESCRIPTION
Die Piraten sind oftmals einfach in ein falsches (leeres) Ozeanfeld
gesegelt, wenn es irgendwo ein Opfer gab.
