### PR TITLE
Hunger und Segeltalent

### DIFF
--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1280,12 +1280,11 @@ static int att_modification(const unit * u, skill_t sk)
     return (int)result;
 }
 
-int
-get_modifier(const unit * u, skill_t sk, int level, const region * r,
-bool noitem)
+int get_modifier(const unit * u, skill_t sk, int level, const region * r, bool noitem)
 {
     int bskill = level;
     int skill = bskill;
+    int hunger_red_skill = -1;
 
     if (r && sk == SK_STEALTH) {
         plane *pl = rplane(r);
@@ -1302,16 +1301,18 @@ bool noitem)
     }
     skill = skillmod(u->attribs, u, r, sk, skill, SMF_ALWAYS);
 
-#ifdef HUNGER_REDUCES_SKILL
-    if (fval(u, UFL_HUNGER)) {
-        if (sk == SK_SAILING && skill > 2) {
+    if (hunger_red_skill == -1) {
+        hunger_red_skill = get_param_int(global.parameters, "rules.hunger.reduces_skill", 2);
+    }
+
+    if (fval(u, UFL_HUNGER) && hunger_red_skill) {
+        if (sk == SK_SAILING && skill > 2 && hunger_red_skill == 2) {
             skill = skill - 1;
         }
         else {
             skill = skill / 2;
         }
     }
-#endif
     return skill - bskill;
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -29,9 +29,6 @@
 #define BATTLE_KILLS_PEASANTS 20
 #define PEASANTLUCK			10
 
-#define HUNGER_REDUCES_SKILL    /* Hunger reduziert den Talentwert
-                                   auf die Hälfte */
-
 #define ASTRAL_ITEM_RESTRICTIONS        /* keine grossen dinge im astralraum */
 #define NEW_DAEMONHUNGER_RULE
 #define NEW_COMBATSKILLS_RULE


### PR DESCRIPTION
Hungernde Einheiten verlieren nur noch einen Punkt Segeln (ab T2), nicht
mehr das halbe Talent.
Das sollte die meisten Schiffsunfälle durch vergessene Silber derart
abschwächen, das die Schiffe noch aus eigener Kraft zum nächsten Hafen
kommen.
