### PR TITLE
Arbeitsplätze

### DIFF
--- a/src/kernel/config.c
+++ b/src/kernel/config.c
@@ -1508,9 +1508,9 @@ bool idle(faction * f)
 
 int maxworkingpeasants(const struct region *r)
 {
-    int i = production(r) * MAXPEASANTS_PER_AREA
-        - ((rtrees(r, 2) + rtrees(r, 1) / 2) * TREESIZE);
-    return _max(i, 0);
+    int size = production(r);
+    int treespace = (rtrees(r, 2) + rtrees(r, 1) / 2) * TREESIZE;
+    return _max(size-treespace, _min(size / 10 , 200));
 }
 
 int lighthouse_range(const building * b, const faction * f)

--- a/src/kernel/config.h
+++ b/src/kernel/config.h
@@ -46,8 +46,7 @@ extern "C" {
 # define MAXUNITS 1048573       /* must be prime for hashing. 524287 was >90% full */
 #endif
 
-#define MAXPEASANTS_PER_AREA 10 /* number of peasants per region-size */
-#define TREESIZE (MAXPEASANTS_PER_AREA-2)       /* space used by trees (in #peasants) */
+#define TREESIZE (8)            /* space used by trees (in #peasants) */
 
 #define PEASANTFORCE 0.75       /* Chance einer Vermehrung trotz 90% Auslastung */
 #define HERBROTCHANCE 5         /* Verrottchance für Kräuter (ifdef HERBS_ROT) */

--- a/src/kernel/region.c
+++ b/src/kernel/region.c
@@ -1187,7 +1187,7 @@ void terraform_region(region * r, const terrain_type * terrain)
 int production(const region * r)
 {
   /* muß rterrain(r) sein, nicht rterrain() wegen rekursion */
-  int p = r->terrain->size / MAXPEASANTS_PER_AREA;
+  int p = r->terrain->size;
   if (curse_active(get_curse(r->attribs, ct_find("drought"))))
     p /= 2;
 

--- a/src/laws.c
+++ b/src/laws.c
@@ -490,7 +490,7 @@ static void peasants(region * r)
 {
     int peasants = rpeasants(r);
     int money = rmoney(r);
-    int maxp = production(r) * MAXPEASANTS_PER_AREA;
+    int maxp = production(r);
     int n, satiated;
     int dead = 0;
 
@@ -781,7 +781,7 @@ growing_trees(region * r, const int current_season, const int last_weeks_season)
 
         /* Grundchance 1.0% */
         /* Jeder Elf in der Region erhöht die Chance marginal */
-        elves = _min(elves, (production(r) * MAXPEASANTS_PER_AREA) / 8);
+        elves = _min(elves, production(r) / 8);
         if (elves) {
             seedchance += 1.0 - pow(0.99999, elves * RESOURCE_QUANTITY);
         }


### PR DESCRIPTION
Regionen haben jetzt immer mindestens 10% ihrer size als freie Freie
Arbeitsplätzt, höchstens jedoch 200.  Das sorgt dafür das die Bäume
nicht alle Bauern umbringen. Diese ernähren sich quasi durch Jagt statt
Ackerbau.
Sinnlose Variable MAXPEASANTS_PER_AREA entfernt.
