### PR TITLE
Fix für Leere Gebäude

### DIFF
--- a/src/economy.c
+++ b/src/economy.c
@@ -1039,12 +1039,10 @@ static bool maintain(building * b, bool first)
     u = building_owner(b);
     if (u == NULL)
         return false;
-    /* If the owner is the region owner, check if biggest castle has the dontpay flag */
+    /* If the owner is the region owner, check if dontpay flag is set for the building where he is in */
     if (check_param(global.parameters, "rules.region_owner_pay_building", b->type->_name)) {
-        if (u == building_owner(largestbuilding(r, &cmp_taxes, false))) {
-            if (fval(u->building, BLD_DONTPAY)) {
-                return false;
-            }
+        if (fval(u->building, BLD_DONTPAY)) {
+            return false;
         }
     }
     for (c = 0; b->type->maintenance[c].number; ++c) {


### PR DESCRIPTION
Der check war sinnlos, denn u->building wobei u der Besitzer ist, gibt
ja im Fall das er der "Besitzer der größten Burg in der Region" ist eben
diese Burg zurück.

So geht das dann auch in E2.
Nicht das
param name="rules.region_owner_pay_building" value="harbour lighthouse"/
in der Config.xml vergessen.
