### PR TITLE
Update wormholes to the module naming convention.

### DIFF
--- a/src/eressea.c
+++ b/src/eressea.c
@@ -64,7 +64,7 @@ void game_init(void)
 #if ARENA_MODULE
     register_arena();
 #endif
-    register_wormholes();
+    wormholes_register();
 
     register_itemtypes();
 #ifdef USE_LIBXML2

--- a/src/laws.c
+++ b/src/laws.c
@@ -4481,7 +4481,7 @@ void processorders(void)
 
     /* must happen AFTER age, because that would destroy them right away */
     if (get_param_int(global.parameters, "modules.wormholes", 0)) {
-        create_wormholes();
+        wormholes_update();
     }
 
     /* immer ausführen, wenn neue Sprüche dazugekommen sind, oder sich

--- a/src/wormhole.c
+++ b/src/wormhole.c
@@ -103,8 +103,7 @@ static int wormhole_age(struct attrib *a)
     return AT_AGE_KEEP;
 }
 
-static void
-wormhole_write(const struct attrib *a, const void *owner, struct storage *store)
+static void wormhole_write(const struct attrib *a, const void *owner, struct storage *store)
 {
     wormhole_data *data = (wormhole_data *)a->data.v;
     write_building_reference(data->entry, store);
@@ -175,7 +174,7 @@ make_wormhole(const building_type * bt_wormhole, region * r1, region * r2)
 
 #define WORMHOLE_CHANCE 10000
 
-void select_wormhole_regions(quicklist **rlistp, int *countp) {
+static void select_wormhole_regions(quicklist **rlistp, int *countp) {
     quicklist *rlist = 0;
     region *r = regions;
     int count = 0;
@@ -217,7 +216,7 @@ void make_wormholes(region **match, int count, const building_type *bt_wormhole)
     }
 }
 
-void create_wormholes(void)
+void wormholes_update(void)
 {
     const building_type *bt_wormhole = bt_find("wormhole");
     quicklist *rlist = 0;
@@ -239,7 +238,7 @@ void create_wormholes(void)
     free(match);
 }
 
-void register_wormholes(void)
+void wormholes_register(void)
 {
     at_register(&at_wormhole);
 }

--- a/src/wormhole.h
+++ b/src/wormhole.h
@@ -22,8 +22,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 extern "C" {
 #endif
 
-  extern void create_wormholes(void);
-  extern void register_wormholes(void);
+  extern void wormholes_update(void);
+  extern void wormholes_register(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- register = called before game is loaded
- init = called after game is loaded
- update = called after the turn, before reports are written
