### PR TITLE
fix messages for magic streets and good/bad dreams

### DIFF
--- a/src/spells/regioncurse.c
+++ b/src/spells/regioncurse.c
@@ -74,10 +74,11 @@ static message *cinfo_dreamcurse(const void *obj, objtype_t typ, const curse * c
   unused_arg(obj);
   assert(typ == TYP_REGION);
 
-  if (curse_geteffect(c) > 0) {
+  if (c->effect > 0) {
     return msg_message("curseinfo::gooddream", "id", c->no);
+  } else {
+    return msg_message("curseinfo::baddream", "id", c->no);
   }
-  return msg_message("curseinfo::baddream", "id", c->no);
 }
 
 static struct curse_type ct_gbdream = {

--- a/src/spells/regioncurse.c
+++ b/src/spells/regioncurse.c
@@ -99,7 +99,7 @@ static message *cinfo_magicstreet(const void *obj, objtype_t typ, const curse * 
   assert(typ == TYP_REGION);
 
   /* Warnung vor Auflösung */
-  if (c->duration <= 2) {
+  if (c->duration >= 2) {
     return msg_message("curseinfo::magicstreet", "id", c->no);
   }
   return msg_message("curseinfo::magicstreetwarn", "id", c->no);


### PR DESCRIPTION
The messages for normal and almost ending magic streets were the wrong way round (bug #2066).
In the first week, both good and bad dreams were reported as bad dreams (bug #1511).