### PR TITLE
Gebäudekapazität nutzt das Gewicht der Personen

### DIFF
--- a/conf/e3/config.xml
+++ b/conf/e3/config.xml
@@ -130,6 +130,7 @@
     <param name="rules.combat.demon_vampire" value="5"/> <!-- regen 1 hp per X points of damage done -->
     <param name="rules.combat.skill_bonus" value="0"/>
     <param name="rules.combat.nat_armor" value="1"/>
+    <param name="rules.combat.castles_use_unit_weigth" value="1"/>
     <!--param name="rules.combat.loot" value="5"/--> <!-- only self + others - keeploot -->
     <param name="rules.items.loot_divisor" value="2"/> <!-- damage skims off 1/2 of goods transfers -->
     <param name="rules.items.give_divisor" value="2"/> <!-- corruption skims off 1/2 of goods transfers -->

--- a/conf/e4/config.xml
+++ b/conf/e4/config.xml
@@ -129,6 +129,7 @@
     <param name="rules.combat.demon_vampire" value="5"/> <!-- regen 1 hp per X points of damage done -->
     <param name="rules.combat.skill_bonus" value="0"/>
     <param name="rules.combat.nat_armor" value="1"/>
+    <param name="rules.combat.castles_use_unit_weigth" value="1"/>
     <!--param name="rules.combat.loot" value="5"/--> <!-- only self + others - keeploot -->
     <param name="rules.items.loot_divisor" value="2"/> <!-- damage skims off 1/2 of goods transfers -->
     <param name="rules.items.give_divisor" value="2"/> <!-- corruption skims off 1/2 of goods transfers -->

--- a/res/buildings/castle-2.xml
+++ b/res/buildings/castle-2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<building name="castle" capacity="1">
+<building name="castle" capacity="4">
   <function name="name" value="castle_name_2"/>
   <function name="protection" value="building_protection"/>
   <function name="taxes" value="lua_building_taxes"/>

--- a/src/battle.c
+++ b/src/battle.c
@@ -2048,6 +2048,25 @@ void dazzle(battle * b, troop * td)
     td->fighter->person[td->index].defence--;
 }
 
+int new_castle_rule(void)
+{
+    int value = -1;
+    if (value < 0) {
+        /* If the parameter is 0, use old rules. Else use size * capacity (from xml building config) * 1000 */
+        /* and use race weight to calculate how many fighter a castle can hold */
+        value = get_param_int(global.parameters, "rules.combat.castles_use_unit_weigth", 0);
+    }
+    return value;    
+}
+
+int castle_capacity(building * b)
+{
+    if (new_castle_rule()) {
+        return buildingcapacity(b) * 1000;  /* CTD Using race weight like E3-ships*/
+    }
+    return buildingcapacity(b);
+}
+
 void damage_building(battle * b, building * bldg, int damage_abs)
 {
     bldg->size = _max(1, bldg->size - damage_abs);
@@ -2057,18 +2076,29 @@ void damage_building(battle * b, building * bldg, int damage_abs)
     if (bldg->type->protection) {
         side *s;
 
-        bldg->sizeleft = bldg->size;
+        bldg->sizeleft = castle_capacity(bldg);
 
         for (s = b->sides; s != b->sides + b->nsides; ++s) {
             fighter *fig;
             for (fig = s->fighters; fig; fig = fig->next) {
                 if (fig->building == bldg) {
-                    if (bldg->sizeleft >= fig->unit->number) {
-                        fig->building = bldg;
-                        bldg->sizeleft -= fig->unit->number;
-                    }
+                    if (new_castle_rule()) {
+                        if (bldg->sizeleft >= (fig->unit->number * u_race(fig->unit)->weight)) {
+                            fig->building = bldg;
+                            bldg->sizeleft -= (fig->unit->number * u_race(fig->unit)->weight);
+                        }
+                        else {
+                            fig->building = NULL;
+                        }
+                    } 
                     else {
-                        fig->building = NULL;
+                        if (bldg->sizeleft >= fig->unit->number) {
+                            fig->building = bldg;
+                            bldg->sizeleft -= fig->unit->number;
+                        }
+                        else {
+                            fig->building = NULL;
+                        }
                     }
                 }
             }
@@ -3255,9 +3285,17 @@ fighter *make_fighter(battle * b, unit * u, side * s1, bool attack)
     }
     else {
         building *bld = u->building;
-        if (bld && bld->sizeleft >= u->number && playerrace(u_race(u))) {
-            fig->building = bld;
-            fig->building->sizeleft -= u->number;
+        if (new_castle_rule()) {
+            if (bld && bld->sizeleft >= u->number * u_race(u)->weight && playerrace(u_race(u))) { /* CTD Using race weight like E3-ships*/
+                fig->building = bld;
+                fig->building->sizeleft -= u->number * u_race(u)->weight;
+            }
+        }
+        else {
+            if (bld && bld->sizeleft >= u->number && playerrace(u_race(u))) {
+                fig->building = bld;
+                fig->building->sizeleft -= u->number;
+            }
         }
     }
     fig->status = u->status;
@@ -3586,7 +3624,7 @@ battle *make_battle(region * r)
 
     /* Alle Mann raus aus der Burg! */
     for (bld = r->buildings; bld != NULL; bld = bld->next)
-        bld->sizeleft = bld->size;
+        bld->sizeleft = castle_capacity(bld);
 
     if (battledebug) {
         char zText[MAX_PATH];

--- a/src/battle.test.c
+++ b/src/battle.test.c
@@ -79,6 +79,8 @@ static void test_defenders_get_building_bonus(CuTest * tc)
     r = findregion(0, 0);
     btype = bt_get_or_create("castle");
     btype->protection = &add_two;
+    btype->capacity = 1;
+    btype->maxcapacity = -1;
     bld = test_create_building(r, btype);
     bld->size = 10;
 
@@ -124,6 +126,8 @@ static void test_attackers_get_no_building_bonus(CuTest * tc)
     r = findregion(0, 0);
     btype = bt_get_or_create("castle");
     btype->protection = &add_two;
+    btype->capacity = 1;
+    btype->maxcapacity = -1;
     bld = test_create_building(r, btype);
     bld->size = 10;
 
@@ -155,6 +159,8 @@ static void test_building_bonus_respects_size(CuTest * tc)
     r = findregion(0, 0);
     btype = bt_get_or_create("castle");
     btype->protection = &add_two;
+    btype->capacity = 1;
+    btype->maxcapacity = -1;
     bld = test_create_building(r, btype);
     bld->size = 10;
 
@@ -192,6 +198,8 @@ static void test_building_defence_bonus(CuTest * tc)
     btype = bt_get_or_create("castle");
     btype->protection = (int (*)(struct building *, struct unit *, building_bonus))get_function("building_protection");
     btype->construction->defense_bonus = 3;
+    btype->capacity = 1;
+    btype->maxcapacity = -1;
     bld = test_create_building(r, btype);
     bld->size = 1;
     


### PR DESCRIPTION
Statt einfach nur die Anzahl um den Platz in einer Burg während eines
Kampfes zu berechnen.
Für E3+E4 aktiviert und die Kapazität auf 4 gesetzt.
In eine 6er Burg passen also 12 Trolle oder 24 Menschen oder 40 Goblins.