### PR TITLE
Peasantgrowth acceleration

### DIFF
--- a/res/core/messages.xml
+++ b/res/core/messages.xml
@@ -3658,6 +3658,13 @@
     <text locale="fr">"$unit($unit): '$order($command)' - The unit already uses $resource($using,0)."</text>
     <text locale="en">"$unit($unit): '$order($command)' - The unit already uses $resource($using,0)."</text>
   </message>
+  <message name="peasantluck_success" section="events">
+    <type>
+      <arg name="births" type="int"/>
+    </type>
+    <text locale="de">"$if($eq($births,1),"Einen Bauern","$int($births) Bauern") besucht unverhofft der Storch."</text>
+    <text locale="en">"The stork paid an unexpected visit to $if($eq($births,1),"one peasant","$int($births) peasants")."</text>
+  </message>
   <message name="shipsink" section="events">
     <type>
       <arg name="ship" type="ship"/>

--- a/src/laws.c
+++ b/src/laws.c
@@ -258,11 +258,20 @@ static void calculate_emigration(region * r)
     }
 }
 
+
+static float peasant_growth_factor(void) {
+    return get_param_flt(global.parameters, "rules.peasants.growth.factor", 
+			 0.0001F * PEASANTGROWTH);
+}
+
 /** Bauern vermehren sich */
 #ifndef SLOWLUCK
 int peasant_luck_effect(int peasants, int luck, int maxp) {
     int births=0;
-    double mean = _min(luck, peasants) * PEASANTLUCK * PEASANTGROWTH / (float) 10000 * ((peasants/(float)maxp < .9)?1:PEASANTFORCE);
+    double mean = _min(luck, peasants)
+	* get_param_int(global.parameters, "rules.peasants.peasantluck.factor", PEASANTLUCK)
+	* peasant_growth_factor()
+	* ((peasants/(float)maxp < .9)?1:PEASANTFORCE);
     
     births = RAND_ROUND(normalvariate(mean, mean/2+1));
     if (births <= 0)
@@ -284,7 +293,7 @@ int peasant_luck_effect(int peasants, int luck, int maxp) {
 	}
 
 	while (chances--) {
-	    if (rng_int() % 10000 < PEASANTGROWTH) {
+	    if (rng_double() < peasant_growth_factor()) {
 		/* Only raise with 75% chance if peasants have
 		 * reached 90% of maxpopulation */
 		if (peasants / (float)maxp < 0.9 || chance(PEASANTFORCE)) {
@@ -307,7 +316,7 @@ static void peasants(region * r)
 
     if (peasants > 0 && get_param_int(global.parameters, "rules.peasants.growth", 1)) {
         int luck = 0;
-        double fraction = peasants * 0.0001F * PEASANTGROWTH;
+        double fraction = peasants * peasant_growth_factor();
         int births = RAND_ROUND(fraction);
         attrib *a = a_find(r->attribs, &at_peasantluck);
 

--- a/src/laws.c
+++ b/src/laws.c
@@ -285,7 +285,7 @@ static void peasants(region * r)
             glueck = a->data.i * 1000;
         }
 
-        for (n = peasants; n; --n) {
+        for (n = peasants; n && glueck; --n) {
             int chances = 0;
 
             if (glueck > 0) {

--- a/src/laws.c
+++ b/src/laws.c
@@ -259,7 +259,8 @@ static void calculate_emigration(region * r)
 }
 
 /** Bauern vermehren sich */
-int fast_peasant_luck_effect(int peasants, int luck, int maxp) {
+#ifndef SLOWLUCK
+int peasant_luck_effect(int peasants, int luck, int maxp) {
     int births=0;
     double mean = _min(luck, peasants) * PEASANTLUCK * PEASANTGROWTH / (float) 10000 * ((peasants/(float)maxp < .9)?1:PEASANTFORCE);
     
@@ -271,6 +272,7 @@ int fast_peasant_luck_effect(int peasants, int luck, int maxp) {
     return (int)births;
 }
 
+#else
 int peasant_luck_effect(int peasants, int luck, int maxp) {
     int n, births=0;
     for (n = peasants; n && luck; --n) {
@@ -293,6 +295,7 @@ int peasant_luck_effect(int peasants, int luck, int maxp) {
     }
     return births;
 }
+#endif
 
 static void peasants(region * r)
 {

--- a/src/laws.c
+++ b/src/laws.c
@@ -305,9 +305,6 @@ static void peasants(region * r)
     int n, satiated;
     int dead = 0;
 
-    /* Bis zu 1000 Bauern können Zwillinge bekommen oder 1000 Bauern
-     * wollen nicht! */
-
     if (peasants > 0 && get_param_int(global.parameters, "rules.peasants.growth", 1)) {
         int luck = 0;
         double fraction = peasants * 0.0001F * PEASANTGROWTH;
@@ -318,8 +315,10 @@ static void peasants(region * r)
             luck = a->data.i * 1000;
         }
 
-	births += peasant_luck_effect(peasants, luck, maxp);
-        peasants += births;
+	luck = peasant_luck_effect(peasants, luck, maxp);
+	ADDMSG(&r->msgs, msg_message("peasantluck_success", "births", luck));
+
+        peasants += births + luck;
     }
 
     /* Alle werden satt, oder halt soviele für die es auch Geld gibt */

--- a/src/laws.h
+++ b/src/laws.h
@@ -107,9 +107,6 @@ extern "C" {
   int armedmen(const struct unit *u, bool siege_weapons);
   void force_leave(struct region *r);
 
-    int peasant_luck_effect(int peasants, int luck, int maxp);
-    int fast_peasant_luck_effect(int peasants, int luck, int maxp);
-
 
 #ifdef __cplusplus
 }

--- a/src/laws.h
+++ b/src/laws.h
@@ -107,6 +107,9 @@ extern "C" {
   int armedmen(const struct unit *u, bool siege_weapons);
   void force_leave(struct region *r);
 
+    int peasant_luck_effect(int peasants, int luck, int maxp);
+    int fast_peasant_luck_effect(int peasants, int luck, int maxp);
+
 
 #ifdef __cplusplus
 }

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -16,6 +16,7 @@
 #include <util/base36.h>
 #include <util/language.h>
 #include <util/message.h>
+#include <util/rand.h>
 
 #include <CuTest.h>
 #include <tests.h>
@@ -691,6 +692,35 @@ static void test_reserve_self(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_peasant_luck(CuTest *tc) {
+    int p, l, max, n=0, wrong=0, total=0;
+    for (p=1; p<10000; p = (int)(_max(p*1.2+1, p+50))) {
+	for (l=1; l<2000; l=(int)(_max(l*1.5+1, l+10))) {
+	    for (max=p/5; max<7*p; max=(int)(max*2+1)) {
+		double births = 0, births2=0, bsum1, bsum2;
+		double birthsm =  l * PEASANTLUCK * PEASANTGROWTH / (float) 10000 * ((p/(float)max < .9)?1:PEASANTFORCE);
+		for (n=0;n<10;++n) {
+		    births = peasant_luck_effect(p, l, max);
+		    births2 = fast_peasant_luck_effect(p,l,max);
+		    bsum1 += births;
+		    bsum2 += births2;
+		    printf("%f\t%f\t%f\t%d\t%d\t%d\t1#\n", birthsm, births2, births, p,l,max);
+		}
+		bsum1 /= 50;
+		bsum2 /= 50;
+		if ((bsum1-bsum2>.5 || bsum2-bsum1>.5) && (bsum1/bsum2>1.1 || bsum2/bsum1>1.1)){
+		    ++wrong;
+		}
+		++total;
+	    }
+	}
+	printf("#\n");
+    }
+    printf("%d / %d\n", wrong, total);
+
+}
+
+
 CuSuite *get_laws_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -721,6 +751,7 @@ CuSuite *get_laws_suite(void)
     SUITE_ADD_TEST(suite, test_force_leave_buildings);
     SUITE_ADD_TEST(suite, test_force_leave_ships);
     SUITE_ADD_TEST(suite, test_force_leave_ships_on_ocean);
+    SUITE_ADD_TEST(suite, test_peasant_luck);
 
     return suite;
 }

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -692,35 +692,6 @@ static void test_reserve_self(CuTest *tc) {
     test_cleanup();
 }
 
-static void test_peasant_luck(CuTest *tc) {
-    int p, l, max, n=0, wrong=0, total=0;
-    for (p=1; p<10000; p = (int)(_max(p*1.2+1, p+50))) {
-	for (l=1; l<2000; l=(int)(_max(l*1.5+1, l+10))) {
-	    for (max=p/5; max<7*p; max=(int)(max*2+1)) {
-		double births = 0, births2=0, bsum1, bsum2;
-		double birthsm =  l * PEASANTLUCK * PEASANTGROWTH / (float) 10000 * ((p/(float)max < .9)?1:PEASANTFORCE);
-		for (n=0;n<10;++n) {
-		    births = peasant_luck_effect(p, l, max);
-		    births2 = fast_peasant_luck_effect(p,l,max);
-		    bsum1 += births;
-		    bsum2 += births2;
-		    printf("%f\t%f\t%f\t%d\t%d\t%d\t1#\n", birthsm, births2, births, p,l,max);
-		}
-		bsum1 /= 50;
-		bsum2 /= 50;
-		if ((bsum1-bsum2>.5 || bsum2-bsum1>.5) && (bsum1/bsum2>1.1 || bsum2/bsum1>1.1)){
-		    ++wrong;
-		}
-		++total;
-	    }
-	}
-	printf("#\n");
-    }
-    printf("%d / %d\n", wrong, total);
-
-}
-
-
 CuSuite *get_laws_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -751,7 +722,6 @@ CuSuite *get_laws_suite(void)
     SUITE_ADD_TEST(suite, test_force_leave_buildings);
     SUITE_ADD_TEST(suite, test_force_leave_ships);
     SUITE_ADD_TEST(suite, test_force_leave_ships_on_ocean);
-    SUITE_ADD_TEST(suite, test_peasant_luck);
 
     return suite;
 }

--- a/src/test_eressea.c
+++ b/src/test_eressea.c
@@ -53,6 +53,7 @@ int RunAllTests(void)
   RUN_TESTS(suite, umlaut);
   RUN_TESTS(suite, unicode);
   RUN_TESTS(suite, strings);
+  RUN_TESTS(suite, rng);
   /* kernel */
   RUN_TESTS(suite, alliance);
   RUN_TESTS(suite, unit);

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -9,6 +9,7 @@ bsdstring.test.c
 functions.test.c
 umlaut.test.c
 unicode.test.c
+rng.test.c
 )
 
 SET(_FILES

--- a/src/util/rng.h
+++ b/src/util/rng.h
@@ -39,6 +39,7 @@ extern "C" {
 # define rng_double ((rand()%RAND_MAX)/(double)RAND_MAX)
 # define RNG_RAND_MAX RAND_MAX
 #endif
+#define RAND_ROUND(fractional) ((rng_double() < fractional-(int)fractional)?((int)fractional+1):((int)fractional))
 #ifdef __cplusplus
 }
 #endif

--- a/src/util/rng.test.c
+++ b/src/util/rng.test.c
@@ -1,0 +1,26 @@
+#include <CuTest.h>
+#include <ctype.h>
+
+#include "rng.h"
+
+static void test_rng_round(CuTest * tc)
+{
+    double f;
+    int i,r;
+    for (i=0; i<1000; ++i) {
+	f = rng_double();
+	r = RAND_ROUND(f);
+	CuAssertTrue(tc, f >= 0);
+	CuAssertTrue(tc, r <= (int) f+1);
+	CuAssertTrue(tc, r >= (int) f);
+	CuAssertTrue(tc, r == (int) r);
+	CuAssertTrue(tc, r == RAND_ROUND(r));
+    }
+}
+
+CuSuite *get_rng_suite(void)
+{
+  CuSuite *suite = CuSuiteNew();
+  SUITE_ADD_TEST(suite, test_rng_round);
+  return suite;
+}


### PR DESCRIPTION
Die Berechnung des Effekts von Bauernlieb war wahnsinnig ineffizient und das sogar, wenn es kein Bauernlieb aktiv war. Habe das neu implementiert und die Wirkung dabei ein winziges bisschen verstärkt. Es gibt jetzt immer mindestens einen Bauern dazu.