### PR TITLE
addendum to monster name fix

### DIFF
--- a/src/kernel/faction.test.c
+++ b/src/kernel/faction.test.c
@@ -70,9 +70,12 @@ static void test_remove_dead_factions(CuTest *tc) {
 
 static void test_addfaction(CuTest *tc) {
     faction *f = 0;
-    const struct race *rc = rc_get_or_create("human");
-    const struct locale *lang = get_or_create_locale("en");
+    const struct race *rc;
+    const struct locale *lang;
 
+    test_cleanup();
+    rc = rc_get_or_create("human");
+    lang = get_or_create_locale("en");
     f = addfaction("test@eressea.de", "hurrdurr", rc, lang, 1234);
     CuAssertPtrNotNull(tc, f);
     CuAssertPtrNotNull(tc, f->name);

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1461,6 +1461,28 @@ static void createunitid(unit * u, int id)
     uhash(u);
 }
 
+void default_name(const unit *u, char name[], int len) {
+    const char * result;
+    const struct locale * lang = u->faction ? u->faction->locale : default_locale;
+    if (lang) {
+        static const char * prefix[MAXLOCALES];
+        int i = locale_index(lang);
+        /*if (!prefix[i]) {*/
+            prefix[i] = LOC(lang, "unitdefault");
+            if (!prefix[i]) {
+                prefix[i] = parameters[P_UNIT];
+            }
+        /*}*/
+        result = prefix[i];
+    }
+    else {
+        result = parameters[P_UNIT];
+    }
+    strlcpy(name, result, len);
+    strlcat(name, " ", len);
+    strlcat(name, itoa36(u->no), len);
+}
+
 void name_unit(unit * u)
 {
     if (u_race(u)->generate_name) {
@@ -1474,25 +1496,7 @@ void name_unit(unit * u)
     }
     else {
         char name[32];
-        const char * result;
-        const struct locale * lang = u->faction ? u->faction->locale : default_locale;
-        if (lang) {
-            static const char * prefix[MAXLOCALES];
-            int i = locale_index(lang);
-            if (!prefix[i]) {
-                prefix[i] = LOC(lang, "unitdefault");
-                if (!prefix[i]) {
-                    prefix[i] = parameters[P_UNIT];
-                }
-            }
-            result = prefix[i];
-        }
-        else {
-            result = parameters[P_UNIT];
-        }
-        strlcpy(name, result, sizeof(name));
-        strlcat(name, " ", sizeof(name));
-        strlcat(name, itoa36(u->no), sizeof(name));
+        default_name(u, name, sizeof(name));
         unit_setname(u, name);
     }
 }

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1631,6 +1631,7 @@ int countheroes(const struct faction *f)
     return n;
 }
 
+/** Returns the raw unit name, like "Frodo", or "Seeschlange" */
 const char *unit_getname(const unit * u)
 {
     if (!u->_name) {
@@ -1883,6 +1884,7 @@ typedef char name[OBJECTIDSIZE + 1];
 static name idbuf[8];
 static int nextbuf = 0;
 
+/** Puts human-readable unit name, with number, like "Frodo (hobb)" into buffer */
 char *write_unitname(const unit * u, char *buffer, size_t size)
 {
     const char * name = unit_getname(u);
@@ -1891,6 +1893,7 @@ char *write_unitname(const unit * u, char *buffer, size_t size)
     return buffer;
 }
 
+/** Returns human-readable unit name, with number, like "Frodo (hobb)" */
 const char *unitname(const unit * u)
 {
     char *ubuf = idbuf[(++nextbuf) % 8];

--- a/src/kernel/unit.h
+++ b/src/kernel/unit.h
@@ -82,14 +82,14 @@ extern "C" {
         struct unit *nextF;         /* nächste Einheit der Partei */
         struct unit *prevF;         /* vorherige Einheit der Partei */
         struct region *region;
-        int no;
+        int no;                     /* id */
         int hp;
         char *_name;
         char *display;
         struct faction *faction;
         struct building *building;
         struct ship *ship;
-        unsigned short number;
+        unsigned short number;      /* persons */
         short age;
 
         /* skill data */
@@ -110,7 +110,7 @@ extern "C" {
         int flags;
         struct attrib *attribs;
         status_t status;
-        int n;                      /* enno: attribut? */
+        int n;                      /* helper temporariy variable, used in econmy, enno: attribut? */
         int wants;                  /* enno: attribut? */
     } unit;
 

--- a/src/kernel/unit.h
+++ b/src/kernel/unit.h
@@ -248,6 +248,7 @@ extern "C" {
 
     struct unit *findunitr(const struct region *r, int n);
 
+    void default_name(const unit *u, char name[], int len);
     const char *unitname(const struct unit *u);
     char *write_unitname(const struct unit *u, char *buffer, size_t size);
     bool unit_name_equals_race(const struct unit *u);

--- a/src/kernel/unit.test.c
+++ b/src/kernel/unit.test.c
@@ -211,6 +211,27 @@ static void test_names(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_default_name(CuTest *tc) {
+    unit *u;
+    struct locale* lang;
+    char buf[32], compare[32];
+
+    test_cleanup();
+    test_create_world();
+    lang = get_or_create_locale("de");
+    /* FIXME this has no real effect: default_name uses a static buffer that is initialized in some other test. This sucks. */
+    locale_setstring(lang, "unitdefault", "Einheit");
+
+    u = test_create_unit(test_create_faction(test_create_race("human")), findregion(0, 0));
+
+    default_name(u, buf, sizeof(buf));
+
+    sprintf(compare, "Einheit %s", itoa36(u->no));
+    CuAssertStrEquals(tc, compare, buf);
+
+    test_cleanup();
+}
+
 CuSuite *get_unit_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -224,5 +245,6 @@ CuSuite *get_unit_suite(void)
     SUITE_ADD_TEST(suite, test_remove_units_with_dead_faction);
     SUITE_ADD_TEST(suite, test_remove_empty_units_in_region);
     SUITE_ADD_TEST(suite, test_names);
+    SUITE_ADD_TEST(suite, test_default_name);
     return suite;
 }

--- a/src/kernel/unit.test.c
+++ b/src/kernel/unit.test.c
@@ -197,6 +197,20 @@ static void test_update_monster_name(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_names(CuTest *tc) {
+    unit *u;
+
+    test_cleanup();
+    test_create_world();
+    u = test_create_unit(test_create_faction(test_create_race("human")), findregion(0, 0));
+
+    unit_setname(u, "Hodor");
+    unit_setid(u, 5);
+    CuAssertStrEquals(tc, "Hodor", unit_getname(u));
+    CuAssertStrEquals(tc, "Hodor (5)", unitname(u));
+    test_cleanup();
+}
+
 CuSuite *get_unit_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -209,5 +223,6 @@ CuSuite *get_unit_suite(void)
     SUITE_ADD_TEST(suite, test_remove_units_without_faction);
     SUITE_ADD_TEST(suite, test_remove_units_with_dead_faction);
     SUITE_ADD_TEST(suite, test_remove_empty_units_in_region);
+    SUITE_ADD_TEST(suite, test_names);
     return suite;
 }

--- a/src/laws.c
+++ b/src/laws.c
@@ -1834,12 +1834,10 @@ int name_cmd(struct unit *u, struct order *ord)
                 break;
             }
             else {
-                const char *udefault = LOC(u2->faction->locale, "unitdefault");
-                const char *uname = unit_getname(u2);
-                size_t udlen = strlen(udefault);
-                size_t unlen = strlen(uname);
-                if (unlen >= udlen && strncmp(uname, udefault, udlen) != 0) {
-                    cmistake(u2, ord, 244, MSG_EVENT);
+                char udefault[32];
+                default_name(u2, udefault, sizeof(udefault));
+                if (strcmp(unit_getname(u2), udefault) != 0) {
+                    cmistake(u, ord, 244, MSG_EVENT);
                     break;
                 }
             }

--- a/src/names.c
+++ b/src/names.c
@@ -215,7 +215,7 @@ const char *silbe3[SIL3] = {
 
 static const char *generic_name(const unit * u)
 {
-    const char * name = rc_name_s(u_race(u), (u->no == 1) ? NAME_SINGULAR : NAME_PLURAL);
+    const char * name = rc_name_s(u_race(u), (u->number == 1) ? NAME_SINGULAR : NAME_PLURAL);
     return LOC(u->faction->locale, name);
 }
 

--- a/src/spells/combatspells.c
+++ b/src/spells/combatspells.c
@@ -1748,7 +1748,7 @@ int sp_undeadhero(struct castorder * co)
             if (j > 0) {
                 item **ilist;
                 unit *u =
-                    create_unit(r, mage->faction, 0, get_race(RC_UNDEAD), 0, du->_name,
+                    create_unit(r, mage->faction, 0, get_race(RC_UNDEAD), 0, unit_getname(du),
                     du);
 
                 /* new units gets some stats from old unit */


### PR DESCRIPTION
While looking at #142 I came across two bugs:

 fix bug in generic_name, minor improvements
    
    Amusingly, in names::generic_name someone confused u->no instead with u->number to determine
    singular or plural. (And who could blame him, those are terrible names...)

 fix NAME FOREIGN UNIT
    
    RENAME FOREIGN UNIT used a somewhat naive approach to check if a
    unit still had its generic name. Fixed that.