### PR TITLE
Schnelle Schiffe für hohe Talente.

### DIFF
--- a/res/core/de/strings.xml
+++ b/res/core/de/strings.xml
@@ -5721,11 +5721,10 @@
         das 50fache und auch im Kampf werden sich die
         erhöhte Kraft und die trollisch zähe Haut
         positiv auswirken.</text>
-      <text locale="en">This artifact gives the one wearing it
+      <text locale="en">This artifact gives the wearer
         the strength of a cavetroll. He will be able to
-        carry fifty times as much as normal and also in
-        combat his enhanced strength and tough troll
-        skin will serve him well.</text>
+        carry fifty times his normal load, as well as
+        gain strength and tough troll skin in combat.</text>
     </string>
     <string name="auraleak">
       <text locale="de">Der Schwarzmagier kann mit diesem
@@ -5735,7 +5734,7 @@
         Region werden einen Großteil ihrer Aura
         verlieren.</text>
       <text locale="en">With this dark ritual the
-        chaossorcerer causes a deep rift to appear in
+        chaos sorcerer causes a deep rift to appear in
         the astral balance that will tear all magical
         power from a region. All spellcasters in that
         region will lose most of their aura.</text>

--- a/src/kernel/jsonconf.c
+++ b/src/kernel/jsonconf.c
@@ -322,6 +322,9 @@ static void json_ship(cJSON *json, ship_type *st) {
             if (strcmp(child->string, "range") == 0) {
                 st->range = child->valueint;
             }
+            else if (strcmp(child->string, "maxrange") == 0) {
+                st->range_max = child->valueint;
+            }
             else {
                 log_error("ship %s contains unknown attribute %s", json->string, child->string);
             }

--- a/src/kernel/jsonconf.test.c
+++ b/src/kernel/jsonconf.test.c
@@ -155,7 +155,9 @@ static void test_ships(CuTest * tc)
 {
     const char * data = "{\"ships\": { \"boat\" : { "
         "\"construction\" : { \"maxsize\" : 20, \"reqsize\" : 10, \"minskill\" : 1 },"
-        "\"coasts\" : [ \"plain\" ]"
+        "\"coasts\" : [ \"plain\" ],"
+        "\"range\" : 8,"
+        "\"maxrange\" : 16"
         "}}}";
 
     cJSON *json = cJSON_Parse(data);
@@ -175,6 +177,8 @@ static void test_ships(CuTest * tc)
     CuAssertIntEquals(tc, 10, st->construction->reqsize);
     CuAssertIntEquals(tc, 20, st->construction->maxsize);
     CuAssertIntEquals(tc, 1, st->construction->minskill);
+    CuAssertIntEquals(tc, 8, st->range);
+    CuAssertIntEquals(tc, 16, st->range_max);
 
     ter = get_terrain("plain");
     CuAssertPtrNotNull(tc, ter);

--- a/src/kernel/ship.c
+++ b/src/kernel/ship.c
@@ -282,6 +282,20 @@ static int ShipSpeedBonus(const unit * u)
     return 0;
 }
 
+int crew_skill(const ship *sh) {
+    int n = 0;
+    unit *u;
+
+    n = 0;
+
+    for (u = sh->region->units; u; u = u->next) {
+        if (u->ship == sh) {
+            n += eff_skill(u, SK_SAILING, sh->region) * u->number;
+        }
+    }
+    return n;
+}
+
 int shipspeed(const ship * sh, const unit * u)
 {
     double k = sh->type->range;
@@ -315,8 +329,11 @@ int shipspeed(const ship * sh, const unit * u)
     }
 
     bonus = ShipSpeedBonus(u);
-    if (bonus > 0) {
-        //
+    if (bonus > 0 && sh->type->range_max>sh->type->range) {
+        int crew = crew_skill(sh);
+        int crew_bonus = (crew / sh->type->sumskill / 2) - 1;
+        bonus = _min(bonus, crew_bonus);
+        bonus = _min(bonus, sh->type->range_max - sh->type->range);
     }
     k += bonus;
 

--- a/src/kernel/ship.c
+++ b/src/kernel/ship.c
@@ -289,6 +289,7 @@ int shipspeed(const ship * sh, const unit * u)
     static bool init;
     attrib *a;
     struct curse *c;
+    int bonus;
 
     if (!init) {
         init = true;
@@ -313,7 +314,11 @@ int shipspeed(const ship * sh, const unit * u)
         }
     }
 
-    k += ShipSpeedBonus(u);
+    bonus = ShipSpeedBonus(u);
+    if (bonus > 0) {
+        //
+    }
+    k += bonus;
 
     a = a_find(sh->attribs, &at_speedup);
     while (a != NULL && a->type == &at_speedup) {

--- a/src/kernel/ship.c
+++ b/src/kernel/ship.c
@@ -327,10 +327,6 @@ int shipspeed(const ship * sh, const unit * u)
         c = c->nexthash;
     }
 
-#ifdef SHIPSPEED
-    k *= SHIPSPEED;
-#endif
-
     if (sh->damage)
         k =
         (k * (sh->size * DAMAGE_SCALE - sh->damage) + sh->size * DAMAGE_SCALE -

--- a/src/kernel/ship.h
+++ b/src/kernel/ship.h
@@ -36,6 +36,7 @@ extern "C" {
         char *_name;
 
         int range;                  /* range in regions */
+        int range_max;
         int flags;                  /* flags */
         int combat;                 /* modifier for combat */
         int fishing;                /* weekly income from fishing */

--- a/src/kernel/ship.h
+++ b/src/kernel/ship.h
@@ -126,6 +126,7 @@ extern "C" {
     extern void ship_setname(struct ship *self, const char *name);
     int shipspeed(const struct ship *sh, const struct unit *u);
 
+    int crew_skill(const struct ship *sh);
 #ifdef __cplusplus
 }
 #endif

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1803,7 +1803,7 @@ void scale_number(unit * u, int n)
 
 const struct race *u_irace(const struct unit *u)
 {
-    if (u->irace && skill_enabled(SK_STEALTH)) {
+    if (u->irace) {
         return u->irace;
     }
     return u->_race;

--- a/src/kernel/xmlreader.c
+++ b/src/kernel/xmlreader.c
@@ -505,6 +505,7 @@ static int parse_ships(xmlDocPtr doc)
             st->minskill = xml_ivalue(node, "minskill", st->minskill);
             st->sumskill = xml_ivalue(node, "sumskill", st->sumskill);
             st->range = xml_ivalue(node, "range", st->range);
+            st->range_max = xml_ivalue(node, "range_max", st->range_max);
             st->storm = xml_fvalue(node, "storm", st->storm);
 
             /* reading eressea/ships/ship/construction */

--- a/src/kernel/xmlreader.c
+++ b/src/kernel/xmlreader.c
@@ -505,7 +505,7 @@ static int parse_ships(xmlDocPtr doc)
             st->minskill = xml_ivalue(node, "minskill", st->minskill);
             st->sumskill = xml_ivalue(node, "sumskill", st->sumskill);
             st->range = xml_ivalue(node, "range", st->range);
-            st->range_max = xml_ivalue(node, "range_max", st->range_max);
+            st->range_max = xml_ivalue(node, "maxrange", st->range_max);
             st->storm = xml_fvalue(node, "storm", st->storm);
 
             /* reading eressea/ships/ship/construction */

--- a/src/laws.c
+++ b/src/laws.c
@@ -2765,8 +2765,8 @@ void sinkships(struct region * r)
         ship *sh = *shp;
 
         if (!sh->type->construction || sh->size >= sh->type->construction->maxsize) {
-            if (fval(r->terrain, SEA_REGION) && (!enoughsailors(sh, r)
-                || get_captain(sh) == NULL)) {
+            if (fval(r->terrain, SEA_REGION) &&
+                !(enoughsailors(sh, ship_sailors(sh)) && get_captain(sh))) {
                 /* Schiff nicht seetüchtig */
                 float dmg = get_param_flt(global.parameters,
                     "rules.ship.damage.nocrewocean",

--- a/src/laws.c
+++ b/src/laws.c
@@ -2766,7 +2766,7 @@ void sinkships(struct region * r)
 
         if (!sh->type->construction || sh->size >= sh->type->construction->maxsize) {
             if (fval(r->terrain, SEA_REGION) &&
-                !(enoughsailors(sh, ship_sailors(sh)) && get_captain(sh))) {
+                !(enoughsailors(sh, crew_skill(sh)) && get_captain(sh))) {
                 /* Schiff nicht seetüchtig */
                 float dmg = get_param_flt(global.parameters,
                     "rules.ship.damage.nocrewocean",

--- a/src/move.c
+++ b/src/move.c
@@ -469,18 +469,23 @@ static bool cansail(const region * r, ship * sh)
     return true;
 }
 
-int enoughsailors(const ship * sh, const region * r)
-{
-    int n;
+int ship_sailors(const ship *sh) {
+    int n = 0;
     unit *u;
 
     n = 0;
 
-    for (u = r->units; u; u = u->next) {
-        if (u->ship == sh)
-            n += eff_skill(u, SK_SAILING, r) * u->number;
+    for (u = sh->region->units; u; u = u->next) {
+        if (u->ship == sh) {
+            n += eff_skill(u, SK_SAILING, sh->region) * u->number;
+        }
     }
-    return n >= sh->type->sumskill;
+    return n;
+}
+
+int enoughsailors(const ship * sh, int ship_sailors)
+{
+    return ship_sailors >= sh->type->sumskill;
 }
 
 /* ------------------------------------------------------------- */
@@ -778,7 +783,7 @@ static void drifting_ships(region * r)
 
             assert(sh->type->construction->improvement == NULL);      /* sonst ist construction::size nicht ship_type::maxsize */
             if (captain && sh->size == sh->type->construction->maxsize
-                && enoughsailors(sh, r) && cansail(r, sh)) {
+                && enoughsailors(sh, ship_sailors(sh)) && cansail(r, sh)) {
                 shp = &sh->next;
                 continue;
             }
@@ -1764,7 +1769,7 @@ static bool ship_ready(const region * r, unit * u)
         cmistake(u, u->thisorder, 15, MSG_MOVE);
         return false;
     }
-    if (!enoughsailors(u->ship, r)) {
+    if (!enoughsailors(u->ship, ship_sailors(u->ship))) {
         cmistake(u, u->thisorder, 1, MSG_MOVE);
         /*		mistake(u, u->thisorder,
                                         "Auf dem Schiff befinden sich zuwenig erfahrene Seeleute.", MSG_MOVE); */

--- a/src/move.c
+++ b/src/move.c
@@ -316,7 +316,7 @@ int walkingcapacity(const struct unit *u)
     if (rbelt) {
         int belts = i_get(u->items, rbelt->itype);
         if (belts) {
-            int multi = get_param_flt(global.parameters, "rules.trollbelt.multiplier", STRENGTHMULTIPLIER);
+            int multi = get_param_int(global.parameters, "rules.trollbelt.multiplier", STRENGTHMULTIPLIER);
             n += _min(people, belts) * (multi - 1) * u_race(u)->capacity;
         }
     }

--- a/src/move.c
+++ b/src/move.c
@@ -469,7 +469,7 @@ static bool cansail(const region * r, ship * sh)
     return true;
 }
 
-int ship_sailors(const ship *sh) {
+int crew_skill(const ship *sh) {
     int n = 0;
     unit *u;
 
@@ -483,9 +483,9 @@ int ship_sailors(const ship *sh) {
     return n;
 }
 
-int enoughsailors(const ship * sh, int ship_sailors)
+int enoughsailors(const ship * sh, int crew_skill)
 {
-    return ship_sailors >= sh->type->sumskill;
+    return crew_skill >= sh->type->sumskill;
 }
 
 /* ------------------------------------------------------------- */
@@ -783,7 +783,7 @@ static void drifting_ships(region * r)
 
             assert(sh->type->construction->improvement == NULL);      /* sonst ist construction::size nicht ship_type::maxsize */
             if (captain && sh->size == sh->type->construction->maxsize
-                && enoughsailors(sh, ship_sailors(sh)) && cansail(r, sh)) {
+                && enoughsailors(sh, crew_skill(sh)) && cansail(r, sh)) {
                 shp = &sh->next;
                 continue;
             }
@@ -1769,7 +1769,7 @@ static bool ship_ready(const region * r, unit * u)
         cmistake(u, u->thisorder, 15, MSG_MOVE);
         return false;
     }
-    if (!enoughsailors(u->ship, ship_sailors(u->ship))) {
+    if (!enoughsailors(u->ship, crew_skill(u->ship))) {
         cmistake(u, u->thisorder, 1, MSG_MOVE);
         /*		mistake(u, u->thisorder,
                                         "Auf dem Schiff befinden sich zuwenig erfahrene Seeleute.", MSG_MOVE); */

--- a/src/move.c
+++ b/src/move.c
@@ -469,20 +469,6 @@ static bool cansail(const region * r, ship * sh)
     return true;
 }
 
-int crew_skill(const ship *sh) {
-    int n = 0;
-    unit *u;
-
-    n = 0;
-
-    for (u = sh->region->units; u; u = u->next) {
-        if (u->ship == sh) {
-            n += eff_skill(u, SK_SAILING, sh->region) * u->number;
-        }
-    }
-    return n;
-}
-
 int enoughsailors(const ship * sh, int crew_skill)
 {
     return crew_skill >= sh->type->sumskill;

--- a/src/move.h
+++ b/src/move.h
@@ -61,7 +61,8 @@ extern "C" {
     void run_to(struct unit *u, struct region *to);
     struct unit *is_guarded(struct region *r, struct unit *u, unsigned int mask);
     bool is_guard(const struct unit *u, int mask);
-    int enoughsailors(const struct ship *sh, const struct region *r);
+    int ship_sailors(const struct ship *sh);
+    int enoughsailors(const struct ship *sh, int ship_sailors);
     bool canswim(struct unit *u);
     bool canfly(struct unit *u);
     struct unit *get_captain(const struct ship *sh);

--- a/src/move.h
+++ b/src/move.h
@@ -61,8 +61,7 @@ extern "C" {
     void run_to(struct unit *u, struct region *to);
     struct unit *is_guarded(struct region *r, struct unit *u, unsigned int mask);
     bool is_guard(const struct unit *u, int mask);
-    int crew_skill(const struct ship *sh);
-    int enoughsailors(const struct ship *sh, int ship_sailors);
+    int enoughsailors(const struct ship *sh, int sumskill);
     bool canswim(struct unit *u);
     bool canfly(struct unit *u);
     struct unit *get_captain(const struct ship *sh);

--- a/src/move.h
+++ b/src/move.h
@@ -61,7 +61,7 @@ extern "C" {
     void run_to(struct unit *u, struct region *to);
     struct unit *is_guarded(struct region *r, struct unit *u, unsigned int mask);
     bool is_guard(const struct unit *u, int mask);
-    int ship_sailors(const struct ship *sh);
+    int crew_skill(const struct ship *sh);
     int enoughsailors(const struct ship *sh, int ship_sailors);
     bool canswim(struct unit *u);
     bool canfly(struct unit *u);

--- a/src/spells.c
+++ b/src/spells.c
@@ -4579,7 +4579,7 @@ int sp_illusionary_shapeshift(castorder * co)
     irace = u_irace(u);
     if (irace == u_race(u)) {
         trigger *trestore = trigger_changerace(u, NULL, irace);
-        add_trigger(&u->attribs, "timer", trigger_timeout((int)power + 2,
+        add_trigger(&u->attribs, "timer", trigger_timeout((int)power + 3,
             trestore));
         u->irace = rc;
     }

--- a/src/spy.c
+++ b/src/spy.c
@@ -344,7 +344,7 @@ int setstealth_cmd(unit * u, struct order *ord)
     return 0;
 }
 
-static int crew_skill(region * r, faction * f, ship * sh, skill_t sk)
+static int top_skill(region * r, faction * f, ship * sh, skill_t sk)
 {
     int value = 0;
     unit *u;
@@ -511,7 +511,7 @@ int sabotage_cmd(unit * u, struct order *ord)
         }
         u2 = ship_owner(sh);
         skdiff =
-            eff_skill(u, SK_SPY, r) - crew_skill(r, u2->faction, sh, SK_PERCEPTION);
+            eff_skill(u, SK_SPY, r) - top_skill(r, u2->faction, sh, SK_PERCEPTION);
         if (try_destruction(u, u2, sh, skdiff)) {
             sink_ship(r, sh, buffer, u);
         }

--- a/src/spy.c
+++ b/src/spy.c
@@ -213,7 +213,6 @@ int setstealth_cmd(unit * u, struct order *ord)
     char token[64];
     const char *s;
     int level, rule;
-    const race *trace;
 
     init_order(ord);
     s = gettoken(token, sizeof(token));
@@ -236,47 +235,51 @@ int setstealth_cmd(unit * u, struct order *ord)
         return 0;
     }
 
-    trace = findrace(s, u->faction->locale);
-    if (trace) {
-        /* demons can cloak as other player-races */
-        if (u_race(u) == get_race(RC_DAEMON)) {
-            race_t allowed[] = { RC_DWARF, RC_ELF, RC_ORC, RC_GOBLIN, RC_HUMAN,
-                RC_TROLL, RC_DAEMON, RC_INSECT, RC_HALFLING, RC_CAT, RC_AQUARIAN,
-                NORACE
-            };
-            int i;
-            for (i = 0; allowed[i] != NORACE; ++i)
-                if (get_race(allowed[i]) == trace)
-                    break;
-            if (get_race(allowed[i]) == trace) {
-                u->irace = trace;
-                if (u_race(u)->flags & RCF_SHAPESHIFTANY && get_racename(u->attribs))
-                    set_racename(&u->attribs, NULL);
+    if (skill_enabled(SK_STEALTH)) { /* hack! E3 erlaubt keine Tarnung */
+        const race *trace;
+
+        trace = findrace(s, u->faction->locale);
+        if (trace) {
+            /* demons can cloak as other player-races */
+            if (u_race(u) == get_race(RC_DAEMON)) {
+                race_t allowed[] = { RC_DWARF, RC_ELF, RC_ORC, RC_GOBLIN, RC_HUMAN,
+                    RC_TROLL, RC_DAEMON, RC_INSECT, RC_HALFLING, RC_CAT, RC_AQUARIAN,
+                    NORACE
+                };
+                int i;
+                for (i = 0; allowed[i] != NORACE; ++i)
+                    if (get_race(allowed[i]) == trace)
+                        break;
+                if (get_race(allowed[i]) == trace) {
+                    u->irace = trace;
+                    if (u_race(u)->flags & RCF_SHAPESHIFTANY && get_racename(u->attribs))
+                        set_racename(&u->attribs, NULL);
+                }
+                return 0;
+            }
+
+            /* Singdrachen koennen sich nur als Drachen tarnen */
+            if (u_race(u) == get_race(RC_SONGDRAGON)
+                || u_race(u) == get_race(RC_BIRTHDAYDRAGON)) {
+                if (trace == get_race(RC_SONGDRAGON) || trace == get_race(RC_FIREDRAGON)
+                    || trace == get_race(RC_DRAGON) || trace == get_race(RC_WYRM)) {
+                    u->irace = trace;
+                    if (u_race(u)->flags & RCF_SHAPESHIFTANY && get_racename(u->attribs))
+                        set_racename(&u->attribs, NULL);
+                }
+                return 0;
+            }
+
+            /* Daemomen und Illusionsparteien koennen sich als andere race tarnen */
+            if (u_race(u)->flags & RCF_SHAPESHIFT) {
+                if (playerrace(trace)) {
+                    u->irace = trace;
+                    if ((u_race(u)->flags & RCF_SHAPESHIFTANY) && get_racename(u->attribs))
+                        set_racename(&u->attribs, NULL);
+                }
             }
             return 0;
         }
-
-        /* Singdrachen koennen sich nur als Drachen tarnen */
-        if (u_race(u) == get_race(RC_SONGDRAGON)
-            || u_race(u) == get_race(RC_BIRTHDAYDRAGON)) {
-            if (trace == get_race(RC_SONGDRAGON) || trace == get_race(RC_FIREDRAGON)
-                || trace == get_race(RC_DRAGON) || trace == get_race(RC_WYRM)) {
-                u->irace = trace;
-                if (u_race(u)->flags & RCF_SHAPESHIFTANY && get_racename(u->attribs))
-                    set_racename(&u->attribs, NULL);
-            }
-            return 0;
-        }
-
-        /* Daemomen und Illusionsparteien koennen sich als andere race tarnen */
-        if (u_race(u)->flags & RCF_SHAPESHIFT) {
-            if (playerrace(trace)) {
-                u->irace = trace;
-                if ((u_race(u)->flags & RCF_SHAPESHIFTANY) && get_racename(u->attribs))
-                    set_racename(&u->attribs, NULL);
-            }
-        }
-        return 0;
     }
 
     switch (findparam(s, u->faction->locale)) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -107,7 +107,17 @@ ship * test_create_ship(region * r, const ship_type * stype)
 ship_type * test_create_shiptype(const char * name)
 {
     ship_type * stype = st_get_or_create(name);
-    locale_setstring(default_locale, name, name);
+    stype->cptskill = 1;
+    stype->sumskill = 1;
+    stype->minskill = 1;
+    if (!stype->construction) {
+        stype->construction = calloc(1, sizeof(construction));
+        stype->construction->maxsize = 5;
+        stype->construction->minskill = 1;
+        stype->construction->reqsize = 1;
+        stype->construction->skill = SK_SHIPBUILDING;
+        locale_setstring(default_locale, name, name);
+    }
     return stype;
 }
 


### PR DESCRIPTION
Die Bewegungsweite von Schiffen bekommt einen Bonus durch das Kapitänstalent, wie in E3:

Für je 5 Stufen über dem Mindesttalent des Schiffes (Drachenschiffe: 2) bekommt das Schiff
einen Bonus von +1 auf seine Reichweite. Ein Kapitän Stufe 7 hat also Reichweite 6 mit dem
Drachenschiff.

Dieser Bonus ist allerdings, anders als bei E3, begrenzt durch das Gesamttalent der 
Mannschaft. Für jeden zusätzlichen Punkt Reichweite benötigt die Mannschaft ein Mehr an
Talentsumme entsprechend dem doppelten der minimalen Talentsumme des Schiffes. Für ein Drachenschiff bedeutet das konkret, die Insassen brauchen 100 Punkte pro zusätzlichen Schritt.

Drittens ist der maximale Bonus durch diese Regel limitiert durch die Maximalgeschwindigkeit des Schiffes, es kann also die Geschwindigkeit von gångigen Schiffstypen also nur maximal verdoppelt werden (vor Anwendugn eventueller magischer Effekte). Drachenschiffe bekommen ein erhöhtes Limit, weil ich sie gerne aufwerten möchte.

Seien:
    BS = Basis-Geschwindigkeit des Schiffes
    MS = Maximalgeschwindigkeit des Schiffes (ca. 2*BS)
    SK = Talent(Kapitän), das Kapitäns-Segeltalent
    SM = Summe(Talent(x), x in Mannschaft), die Summe der Segeltalente der Mannschaft
    RK = Das Mindest-Kapitänstalent des Schiffes
    RM = Das für das Schiff minimal nötige Segeltalent der Mannschaft

Dann ist die Reichweite:
    BS + min((SK-RK)/5, SM/RM/2-1, MS)
