### PR TITLE
Spell param bug 2060

### DIFF
--- a/res/e3a/spells.xml
+++ b/res/e3a/spells.xml
@@ -585,7 +585,7 @@
     <!-- Schutzzauber -->
     <resource name="aura" amount="5" cost="level"/>
   </spell>
-  <spell name="protective_runes" rank="2" index="99" parameters="kc" ship="true">
+  <spell name="protective_runes" rank="2" index="99" parameters="kc" regiontarget="false" unittarget="false" buildingtarget="true" shiptarget="true" ship="true">
     <resource name="aura" amount="20" cost="fixed"/>
   </spell>
   <spell name="analyze_magic" rank="5" index="102" parameters="kc?" los="true" ship="true" variable="true">

--- a/res/eressea/spells.xml
+++ b/res/eressea/spells.xml
@@ -310,7 +310,7 @@
   <spell name="keeploot" rank="5" index="98" variable="true" combat="3">
     <resource name="aura" amount="1" cost="level"/>
   </spell>
-  <spell name="protective_runes" rank="2" index="99" parameters="kc" ship="true">
+  <spell name="protective_runes" rank="2" index="99" parameters="kc" regiontarget="false" unittarget="false" buildingtarget="true" shiptarget="true" ship="true">
     <resource name="aura" amount="20" cost="fixed"/>
   </spell>
   <spell name="song_resist_magic" rank="2" index="100" far="true" variable="true">
@@ -329,7 +329,7 @@
     <resource name="aura" amount="10" cost="fixed"/>
   </spell>
   <spell name="analyse_object" rank="5" index="105" parameters="kc+" ship="true" variable="true">
-    <resource name="aura" amount="3" cost="level"/>
+    <resource name="aura" amount="3" cost="level" regiontarget="true" unittarget="false" buildingtarget="true" shiptarget="true"/>
   </spell>
   <spell name="destroy_magic" rank="2" index="106" parameters="kc+" los="true" ship="true" far="true" variable="true">
     <resource name="aura" amount="4" cost="level"/>

--- a/src/kernel/xmlreader.c
+++ b/src/kernel/xmlreader.c
@@ -1472,6 +1472,16 @@ static int parse_spells(xmlDocPtr doc)
                 sp->sptyp |= FARCASTING;
             if (xml_bvalue(node, "variable", false))
                 sp->sptyp |= SPELLLEVEL;
+
+            if (xml_bvalue(node, "buildingtarget", false))
+                sp->sptyp |= BUILDINGSPELL;
+            if (xml_bvalue(node, "shiptarget", false))
+                sp->sptyp |= SHIPSPELL;
+            if (xml_bvalue(node, "unittarget", false))
+                sp->sptyp |= UNITSPELL;
+            if (xml_bvalue(node, "regiontarget", false))
+                sp->sptyp |= REGIONSPELL;
+
             k = xml_ivalue(node, "combat", 0);
             if (k >= 0 && k <= 3)
                 sp->sptyp |= modes[k];

--- a/src/report.c
+++ b/src/report.c
@@ -286,7 +286,7 @@ static void nr_spell(FILE * F, spellbook_entry * sbe, const struct locale *lang)
             if (sp->sptyp & SPELLLEVEL) {
                 bytes =
                     _snprintf(bufp, size, "  %d %s", itemanz, LOC(lang, resourcename(rtype,
-                    itemanz != 1)));
+                        itemanz != 1)));
                 if (wrptr(&bufp, &size, bytes) != 0)
                     WARN_STATIC_BUFFER();
                 if (costtyp == SPC_LEVEL || costtyp == SPC_LINEAR) {
@@ -446,24 +446,24 @@ static void nr_spell(FILE * F, spellbook_entry * sbe, const struct locale *lang)
                 if (sp->sptyp & targetp->flag)
                     ++maxparam;
             }
-            if (maxparam > 1) {
+            if (!maxparam || maxparam > 1) {
                 bytes = (int)strlcpy(bufp, " (", size);
                 if (wrptr(&bufp, &size, bytes) != 0)
                     WARN_STATIC_BUFFER();
             }
             i = 0;
             for (targetp = targets; targetp->flag; ++targetp) {
-                if (sp->sptyp & targetp->flag) {
+                if (!maxparam || sp->sptyp & targetp->flag) {
                     if (i++ != 0) {
                         bytes = (int)strlcpy(bufp, " |", size);
                         if (wrptr(&bufp, &size, bytes) != 0)
                             WARN_STATIC_BUFFER();
                     }
-                    if (targetp->param) {
+                    if (targetp->param && targetp->vars) {
                         locp = LOC(lang, targetp->vars);
                         bytes =
                             (int)_snprintf(bufp, size, " %s <%s>", parameters[targetp->param],
-                            locp);
+                                locp);
                         if (*params == '+') {
                             ++params;
                             if (wrptr(&bufp, &size, bytes) != 0)
@@ -479,7 +479,7 @@ static void nr_spell(FILE * F, spellbook_entry * sbe, const struct locale *lang)
                         WARN_STATIC_BUFFER();
                 }
             }
-            if (maxparam > 1) {
+            if (!maxparam || maxparam > 1) {
                 bytes = (int)strlcpy(bufp, " )", size);
                 if (wrptr(&bufp, &size, bytes) != 0)
                     WARN_STATIC_BUFFER();

--- a/src/spells.c
+++ b/src/spells.c
@@ -685,6 +685,7 @@ static int sp_destroy_magic(castorder * co)
         break;
     }
     default:
+        cmistake(mage, co->order, 213, MSG_MAGIC);
         return 0;
     }
 
@@ -731,8 +732,12 @@ static int sp_transferaura(castorder * co)
     sc_mage *scm_dst, *scm_src = get_mage(mage);
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* wenn Ziel gefunden, dieses aber Magieresistent war, Zauber
      * abbrechen aber kosten lassen */
@@ -808,8 +813,12 @@ static int sp_goodwinds(castorder * co)
     unit *u;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     sh = pa->param[0]->data.sh;
 
@@ -955,8 +964,12 @@ static int sp_blessstonecircle(castorder * co)
     message *msg;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (p->param[0]->flag == TARGET_NOTFOUND)
+    if (p->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     b = p->param[0]->data.b;
 
@@ -1432,8 +1445,12 @@ static int sp_sparkle(castorder * co)
     float effect;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* wenn Ziel gefunden, dieses aber Magieresistent war, Zauber
      * abbrechen aber kosten lassen */
@@ -1620,7 +1637,6 @@ static int sp_great_drought(castorder * co)
 
     if (fval(r->terrain, SEA_REGION)) {
         cmistake(mage, co->order, 189, MSG_MAGIC);
-        /* TODO: vielleicht einen netten Patzer hier? */
         return 0;
     }
 
@@ -2506,8 +2522,12 @@ static int sp_fumblecurse(castorder * co)
     spellparameter *pa = co->par;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;
 
@@ -3447,6 +3467,7 @@ static int sp_analysesong_obj(castorder * co)
     }
     default:
         /* Syntax fehlerhaft */
+        cmistake(mage, co->order, 213, MSG_MAGIC);
         return 0;
     }
 
@@ -3476,8 +3497,12 @@ static int sp_analysesong_unit(castorder * co)
     spellparameter *pa = co->par;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* wenn Ziel gefunden, dieses aber Magieresistent war, Zauber
      * abbrechen aber kosten lassen */
@@ -3563,8 +3588,12 @@ static int sp_charmingsong(castorder * co)
     int tb = 0;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;
 
@@ -3816,8 +3845,12 @@ static int sp_migranten(castorder * co)
     spellparameter *pa = co->par;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;        /* Zieleinheit */
 
@@ -4102,8 +4135,12 @@ static int sp_pump(castorder * co)
     int cast_level = co->level;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;        /* Zieleinheit */
 
@@ -4169,8 +4206,12 @@ static int sp_seduce(castorder * co)
     float force = co->force;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;        /* Zieleinheit */
 
@@ -4247,8 +4288,12 @@ static int sp_calm_monster(castorder * co)
     message *msg;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;        /* Zieleinheit */
 
@@ -4302,8 +4347,12 @@ static int sp_headache(castorder * co)
     target = pa->param[0]->data.u;        /* Zieleinheit */
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (target->number == 0 || pa->param[0]->flag == TARGET_NOTFOUND)
+    if (target->number == 0 || pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* finde das groeßte Talent: */
     for (i = 0; i != target->skill_size; ++i) {
@@ -4478,6 +4527,7 @@ int sp_icastle(castorder * co)
     const building_type *bt_illusion = bt_find("illusioncastle");
 
     if (!bt_illusion) {
+        log_warning("building type illusioncastle not found\n");
         return 0;
     }
 
@@ -4554,8 +4604,12 @@ int sp_illusionary_shapeshift(castorder * co)
     const race *irace;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* wenn Ziel gefunden, dieses aber Magieresistent war, Zauber
      * abbrechen aber kosten lassen */
@@ -4631,8 +4685,12 @@ int sp_analysedream(castorder * co)
     spellparameter *pa = co->par;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* wenn Ziel gefunden, dieses aber Magieresistent war, Zauber
      * abbrechen aber kosten lassen */
@@ -4775,8 +4833,12 @@ int sp_dreamreading(castorder * co)
     message *msg;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* wenn Ziel gefunden, dieses aber Magieresistent war, Zauber
      * abbrechen aber kosten lassen */
@@ -4912,8 +4974,10 @@ int sp_analysemagic(castorder * co)
     spellparameter *pa = co->par;
 
     if (!pa->param) {
+        cmistake(mage, co->order, 213, MSG_MAGIC);
         return 0;
     }
+
     /* Objekt ermitteln */
     obj = pa->param[0]->typ;
 
@@ -4948,6 +5012,7 @@ int sp_analysemagic(castorder * co)
     }
     default:
         /* Fehlerhafter Parameter */
+        cmistake(mage, co->order, 213, MSG_MAGIC);
         return 0;
     }
 
@@ -4966,8 +5031,12 @@ int sp_itemcloak(castorder * co)
     int duration = (int)_max(2.0, power + 1);      /* works in the report, and ageing this round would kill it if it's <=1 */
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* Zieleinheit */
     target = pa->param[0]->data.u;
@@ -5823,8 +5892,12 @@ static int sp_eternizewall(castorder * co)
     message *msg;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     b = pa->param[0]->data.b;
     c = create_curse(mage, &b->attribs, ct_find("nocostbuilding"),
@@ -5888,8 +5961,12 @@ int sp_permtransfer(castorder * co)
     message *msg;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* wenn Ziel gefunden, dieses aber Magieresistent war, Zauber
      * abbrechen aber kosten lassen */
@@ -5945,8 +6022,12 @@ int sp_movecastle(castorder * co)
     message *msg;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     b = pa->param[0]->data.b;
     dir = get_direction(pa->param[1]->data.xs, mage->faction->locale);
@@ -6029,8 +6110,12 @@ int sp_flying_ship(castorder * co)
     int cno;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
     sh = pa->param[0]->data.sh;
     if (sh->type->construction->maxsize > 50) {
         ADDMSG(&mage->faction->msgs, msg_feedback(mage, co->order,
@@ -6049,7 +6134,12 @@ int sp_flying_ship(castorder * co)
         else if (is_cursed(sh->attribs, C_SHIP_SPEEDUP, 0)) {
             /* Es ist zu gefaehrlich, ein sturmgepeitschtes Schiff fliegen zu lassen. */
             cmistake(mage, co->order, 210, MSG_MAGIC);
+        } else {
+            ADDMSG(&mage->faction->msgs,
+                msg_message("spelltargetnotfound", "unit region command",
+                mage, mage->region, co->order));
         }
+
         return 0;
     }
     sh->coast = NODIRECTION;
@@ -6094,8 +6184,12 @@ int sp_stealaura(castorder * co)
     spellparameter *pa = co->par;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     /* Zieleinheit */
     u = pa->param[0]->data.u;
@@ -6256,6 +6350,7 @@ static int sp_magicrunes(castorder * co)
     }
     default:
         /* fehlerhafter Parameter */
+        cmistake(mage, co->order, 213, MSG_MAGIC);
         return 0;
     }
 
@@ -6502,6 +6597,7 @@ int sp_break_curse(castorder * co)
 /* ------------------------------------------------------------- */
 int sp_becomewyrm(castorder * co)
 {
+    log_error("not implemented");
     return 0;
 }
 
@@ -6709,8 +6805,12 @@ static int sp_babbler(castorder * co)
     message *msg;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;
 
@@ -6755,8 +6855,12 @@ static int sp_readmind(castorder * co)
     spellparameter *pa = co->par;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
-    if (pa->param[0]->flag == TARGET_NOTFOUND)
+    if (pa->param[0]->flag == TARGET_NOTFOUND) {
+        ADDMSG(&mage->faction->msgs,
+            msg_message("spelltargetnotfound", "unit region command",
+            mage, mage->region, co->order));
         return 0;
+    }
 
     target = pa->param[0]->data.u;
 


### PR DESCRIPTION
* Report correct syntax for spells with "k" parameters like "Magie analysieren" or "Fluch brechen"
* don't fail silently in spells
