### PR TITLE
trying to test curse_write/read

### DIFF
--- a/src/kernel/curse.test.c
+++ b/src/kernel/curse.test.c
@@ -1,14 +1,26 @@
 #include <platform.h>
-#include "types.h"
-#include "curse.h"
 
+#include <kernel/config.h>
 #include <kernel/region.h>
 #include <kernel/unit.h>
+#include <kernel/version.h>
 #include <util/attrib.h>
 #include <util/message.h>
+#include <binarystore.h>
+#include <filestream.h>
+#include <memstream.h>
+#include <storage.h>
+#include <stream.h>
 #include <tests.h>
 
+#include "curse.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
 #include <CuTest.h>
+
 
 static void test_curse(CuTest * tc)
 {
@@ -83,6 +95,82 @@ static void test_bad_dreams(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_memstream(CuTest *tc) {
+    storage store;
+    stream out = { 0 };
+    char buf[1024];
+    int val=0;
+
+#ifdef FILESTREAMTEST
+    FILE *F;
+    F = fopen("test.dat", "wb");
+    fstream_init(&out, F);
+#else
+    mstream_init(&out);
+#endif
+    binstore_init(&store, &out);
+    store.handle.data = &out;
+
+    WRITE_INT(&store, 999999);
+    WRITE_TOK(&store, "fortytwo");
+    WRITE_INT(&store, 42);
+
+#ifdef FILESTREAMTEST
+    fstream_done(&out);
+    F = fopen("test.dat", "rb");
+    fstream_init(&out, F);
+#endif
+    out.api->rewind(out.handle);
+    READ_INT(&store, &val);
+    READ_TOK(&store, buf, 1024);
+    CuAssertIntEquals(tc, 999999, val);
+    CuAssertStrEquals(tc, "fortytwo", buf);
+    READ_INT(&store, &val);
+    CuAssertIntEquals(tc, 42, val);
+}
+
+static void test_write_flag(CuTest *tc) {
+    curse_fixture fix;
+    storage store;
+    char buf[1024];
+    stream out = { 0 };
+    size_t len;
+#ifdef FILESTREAMTEST
+    FILE *F;
+    F = fopen("test.dat", "wb");
+    fstream_init(&out, F);
+#else
+    mstream_init(&out);
+#endif
+    binstore_init(&store, &out);
+    store.handle.data = &out;
+
+    setup_curse(&fix, "gbdream");
+    fix.c->flags = 42 | CURSE_ISNEW;
+    curse_write(fix.r->attribs, fix.r, &store);
+#ifdef FILESTREAMTEST
+    fstream_done(&out);
+    F = fopen("test.dat", "rb");
+    fstream_init(&out, F);
+#endif
+    out.api->rewind(out.handle);
+    len = out.api->read(out.handle, buf, sizeof(buf));
+    buf[len] = '\0';
+    out.api->rewind(out.handle);
+    curse_read(fix.r->attribs, fix.r, &store);
+    CuAssertIntEquals(tc, 42 | CURSE_ISNEW, ((curse *) fix.r->attribs->data.v)->flags);
+    global.data_version = RELEASE_VERSION;
+    CuAssertIntEquals(tc, RELEASE_VERSION, global.data_version);
+
+#ifdef FILESTREAMTEST
+    fstream_done(&out);
+#else
+    mstream_done(&out);
+#endif
+    binstore_done(&store);
+    test_cleanup();
+}
+
 CuSuite *get_curse_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -91,5 +179,7 @@ CuSuite *get_curse_suite(void)
     SUITE_ADD_TEST(suite, test_magicstreet_warning);
     SUITE_ADD_TEST(suite, test_good_dreams);
     SUITE_ADD_TEST(suite, test_bad_dreams);
+    SUITE_ADD_TEST(suite, test_memstream);
+    SUITE_ADD_TEST(suite, test_write_flag);
     return suite;
 }

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -1724,6 +1724,7 @@ int writegame(const char *filename)
     gdata.store = &store;
     gdata.encoding = enc_gamedata;
     gdata.version = RELEASE_VERSION;
+    global.data_version = RELEASE_VERSION;
     n = STREAM_VERSION;
     fwrite(&gdata.version, sizeof(int), 1, F);
     fwrite(&n, sizeof(int), 1, F);

--- a/src/names.c
+++ b/src/names.c
@@ -357,7 +357,8 @@ static const char *dracoid_name(const unit * u)
     static char name[NAMESIZE + 1]; // FIXME: static return value
     int mid_syllabels;
 
-    u = u;
+    /* ignore u */
+    u = 0;
     /* Wieviele Mittelteile? */
 
     mid_syllabels = rng_int() % 4;


### PR DESCRIPTION
Ich versuchte grade, einen test für curse_read/write zu schreiben. Dabei habe ich memstream benutzt und bin auf folgendes Problem gestoßen (siehe test case test_memstream(), curse.c:114-124). Ist das ein Bug in memstream oder benutze ich memstream hier einfach nur falsch? Mit filestream funktioniert's.

Was passiert:
WRITE_INT(&store, 999999), also eigentlich binary_store:bin_w_int_pak(), ruft memstream:ms_write und erzeugt einen Listeneintrag mit zwei Bytes im Stream (weil 999999 nicht in ein char passt).
READ_INT(&store, &val), also eigentlich binary_store:bin_r_int_pak(), will nun aus dem memstream ein Byte nach dem anderen einlesen, bis er merkt, dass der int komplett ist.
Was aber passiert ist, das in memstream:ms_read das erste Byte gelesen wird, dann wird in memstream.c:55 in der Liste eins weitergegangen. Dabei wird das zweite Byte übersprungen und danach ist alles falsch.
