### PR TITLE
Bug 2103: Fehlende Zauberbeschreibung im englischen CR

### DIFF
--- a/src/util/language.c
+++ b/src/util/language.c
@@ -153,8 +153,13 @@ const char *locale_string(const locale * lang, const char *key, bool warn)
         if (warn) {
             log_warning("missing translation for \"%s\" in locale %s\n", key, lang->name);
         }
-        if (lang->fallback) {
-            return locale_string(lang->fallback, key, warn);
+        if (default_locale && lang != default_locale) {
+            const char * value = locale_string(default_locale, key, warn);
+            if (value) {
+                /* TODO: evil side-effects for a const function */
+                locale_setstring(get_or_create_locale(lang->name), key, value);
+            }
+            return value;
         }
     }
     return 0;

--- a/src/util/language_struct.h
+++ b/src/util/language_struct.h
@@ -19,7 +19,6 @@ typedef struct locale {
     struct locale *next;
     unsigned int hashkey;
     struct locale_str *strings[SMAXHASH];
-    struct locale *fallback;
 } locale;
 
 extern locale *default_locale;


### PR DESCRIPTION
https://bugs.eressea.de/view.php?id=2103