### PR TITLE
fix pool test (GiveRestriction broke it).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ game-e3/reports/
 *.log.*
 tags
 Thumbs.db
+.gdb_history

--- a/conf/eressea.ini
+++ b/conf/eressea.ini
@@ -12,7 +12,6 @@ locales                        = de,en
 install                        = .
 paths                          = lunit:scripts
 maxnmrs                        = 20
-rules                          = e2
 
 [editor]
 color                          = 1

--- a/scripts/eressea/xmlconf.lua
+++ b/scripts/eressea/xmlconf.lua
@@ -2,9 +2,8 @@ local confdir = 'conf/'
 if config.install then
     confdir = config.install .. '/' .. confdir
 end
-rules=''
 if config.rules then
-    rules = config.rules .. '/'
+    local rules = config.rules .. '/'
+    assert(0 == read_xml(confdir .. rules .. 'config.xml', confdir .. rules .. 'catalog.xml'), "could not load XML data, did you compile with LIBXML2 ?")
+    assert(0 == eressea.config.read(rules .. 'config.json', confdir), "could not read JSON data")
 end
-assert(0 == read_xml(confdir .. rules .. 'config.xml', confdir .. rules .. 'catalog.xml'), "could not load XML data, did you compile with LIBXML2 ?")
-assert(0 == eressea.config.read(rules .. 'config.json', confdir), "could not read JSON data")


### PR DESCRIPTION
- do not default to loading the E2 rules for tests, so GiveRestriction
will not be set to a default value.
- only load configuration if a ruleset has been defined.