### PR TITLE
bug 2069: familiar races

### DIFF
--- a/scripts/tests/e2/init.lua
+++ b/scripts/tests/e2/init.lua
@@ -1,3 +1,4 @@
+require 'tests.e2.undead'
 require 'tests.e2.shiplanding'
 require 'tests.e2.e2features'
 require 'tests.e2.movement'

--- a/scripts/tests/e2/undead.lua
+++ b/scripts/tests/e2/undead.lua
@@ -1,0 +1,31 @@
+require "lunit"
+
+module("tests.e2.undead", package.seeall, lunit.testcase)
+
+function setup()
+    eressea.free_game()
+end
+
+function test_undead_give_item()
+    local r1 = region.create(0, 0, "plain")
+    local f1 = faction.create("hodor@eressea.de", "human", "de")
+    local u1 = unit.create(f1, r1, 1)
+    u1.race = "undead"
+    u1:clear_orders()
+    u1:add_item("log", 1)
+    u1:add_order("GIB 0 1 Holz")
+    process_orders()
+    assert_equal(0, u1:get_item("log"))
+end
+
+function test_undead_dont_give_person()
+    local r1 = region.create(0, 0, "plain")
+    local f1 = faction.create("hodor@eressea.de", "human", "de")
+    local u1 = unit.create(f1, r1, 2)
+    u1.race = "undead"
+    u1:clear_orders()
+    u1:add_item("log", 1)
+    u1:add_order("GIB 0 1 Person")
+    process_orders()
+    assert_equal(2, u1.number)
+end

--- a/src/kernel/race.c
+++ b/src/kernel/race.c
@@ -158,6 +158,7 @@ static race *rc_find_i(const char *name)
     }
     if (!rc && strcmp(name, "uruk") == 0) {
         rc = rc_find_i("orc");
+        log_warning("a reference was made to the retired race '%s', returning '%s'.", name, rc->_name);
     }
     return rc;
 }

--- a/src/kernel/race.h
+++ b/src/kernel/race.h
@@ -146,7 +146,6 @@ extern "C" {
         int flags;
         int battle_flags;
         int ec_flags;
-        race_t oldfamiliars[MAXMAGIETYP];
         struct att attack[RACE_ATTACKS];
         signed char bonus[MAXSKILLS];
 

--- a/src/kernel/xmlreader.c
+++ b/src/kernel/xmlreader.c
@@ -1613,7 +1613,7 @@ static int parse_races(xmlDocPtr doc)
         xmlNodePtr node = nodes->nodeTab[i];
         xmlNodePtr child;
         xmlChar *propValue;
-        race *rc;
+        race *rc, *frc = 0;
         xmlXPathObjectPtr result;
         int k, study_speed_base, attacks;
         struct att *attack;
@@ -1810,21 +1810,27 @@ static int parse_races(xmlDocPtr doc)
         /* reading eressea/races/race/familiar */
         xpath->node = node;
         result = xmlXPathEvalExpression(BAD_CAST "familiar", xpath);
-        for (k = 0; k != result->nodesetval->nodeNr; ++k) {
-            xmlNodePtr node = result->nodesetval->nodeTab[k];
-            race *frc;
+        if (result->nodesetval->nodeNr > MAXMAGIETYP) {
+            log_error("race %s has %d potential familiars", rc->_name, result->nodesetval->nodeNr);
+        }
+        for (k = 0; k != MAXMAGIETYP; ++k) {
+            if (k < result->nodesetval->nodeNr) {
+                xmlNodePtr node = result->nodesetval->nodeTab[k];
 
-            propValue = xmlGetProp(node, BAD_CAST "race");
-            assert(propValue != NULL);
-            frc = rc_get_or_create((const char *)propValue);
-            if (xml_bvalue(node, "default", false)) {
-                rc->familiars[k] = rc->familiars[0];
-                rc->familiars[0] = frc;
-            }
-            else {
+                propValue = xmlGetProp(node, BAD_CAST "race");
+                assert(propValue != NULL);
+                frc = rc_get_or_create((const char *)propValue);
+                if (xml_bvalue(node, "default", false)) {
+                    rc->familiars[k] = rc->familiars[0];
+                    rc->familiars[0] = frc;
+                }
+                else {
+                    rc->familiars[k] = frc;
+                }
+                xmlFree(propValue);
+            } else {
                 rc->familiars[k] = frc;
             }
-            xmlFree(propValue);
         }
         xmlXPathFreeObject(result);
 

--- a/src/spells.c
+++ b/src/spells.c
@@ -480,6 +480,7 @@ static const race *select_familiar(const race * magerace, magic_t magiegebiet)
     assert(magerace->familiars[0]);
     if (rnd >= 70) {
         retval = magerace->familiars[magiegebiet];
+        assert(retval);
     }
     else {
         retval = magerace->familiars[0];


### PR DESCRIPTION
Als quick fix werde ich da mal alle Gebiete auf den gleichen Vertrauten setzen, das war glaube ich so gewollt? Das ist jedenfalls die einzig mögliche Interpretation ohne Eingriff in die E3 Konfiguration.
