### PR TITLE
bug 1890: make monsters give GIVE orders

### DIFF
--- a/scripts/eressea/ents.lua
+++ b/scripts/eressea/ents.lua
@@ -16,7 +16,7 @@ end
 local function repair_ents(r)
     for u in r.units do
         if u.faction.id==666 and u.race == "undead" and u.name == "Wütende Ents" then
-            print("ent repair", u)
+            eressea.log.info("ent repair: " .. tostring(u))
             u.race = "ent"
         end
     end

--- a/scripts/tests/e2/init.lua
+++ b/scripts/tests/e2/init.lua
@@ -1,3 +1,4 @@
+require 'tests.e2.undead'
 require 'tests.e2.shiplanding'
 require 'tests.e2.e2features'
 require 'tests.e2.movement'

--- a/scripts/tests/e2/undead.lua
+++ b/scripts/tests/e2/undead.lua
@@ -1,0 +1,31 @@
+require "lunit"
+
+module("tests.e2.undead", package.seeall, lunit.testcase)
+
+function setup()
+    eressea.free_game()
+end
+
+function test_undead_give_item()
+    local r1 = region.create(0, 0, "plain")
+    local f1 = faction.create("hodor@eressea.de", "human", "de")
+    local u1 = unit.create(f1, r1, 1)
+    u1.race = "undead"
+    u1:clear_orders()
+    u1:add_item("log", 1)
+    u1:add_order("GIB 0 1 Holz")
+    process_orders()
+    assert_equal(0, u1:get_item("log"))
+end
+
+function test_undead_dont_give_person()
+    local r1 = region.create(0, 0, "plain")
+    local f1 = faction.create("hodor@eressea.de", "human", "de")
+    local u1 = unit.create(f1, r1, 2)
+    u1.race = "undead"
+    u1:clear_orders()
+    u1:add_item("log", 1)
+    u1:add_order("GIB 0 1 Person")
+    process_orders()
+    assert_equal(2, u1.number)
+end


### PR DESCRIPTION
monsters were giving away things too early in the turn (during plan_monsters). fixed by creating a give order instead of calling give_item directly.