### PR TITLE
Bug 1950: fleeing units can guard the same turn.

### DIFF
--- a/src/laws.c
+++ b/src/laws.c
@@ -2675,7 +2675,7 @@ enum { E_GUARD_OK, E_GUARD_UNARMED, E_GUARD_NEWBIE, E_GUARD_FLEEING };
 
 static int can_start_guarding(const unit * u)
 {
-    if (u->status >= ST_FLEE)
+    if (u->status >= ST_FLEE || fval(u, UFL_FLEEING))
         return E_GUARD_FLEEING;
     if (fval(u_race(u), RCF_UNARMEDGUARD))
         return E_GUARD_OK;


### PR DESCRIPTION
checking for UFL_FLEEING in can_start_guarding should make that impossible now.
https://bugs.eressea.de/view.php?id=1950