### PR TITLE
Bug 1596: Schwer verwundete fliehen auch nach der Taktik-Runde.

### DIFF
--- a/src/battle.c
+++ b/src/battle.c
@@ -4206,8 +4206,6 @@ static void battle_flee(battle * b)
                     default:
                         if ((fig->person[dt.index].flags & FL_HIT) == 0)
                             continue;
-                        if (b->turn <= 1)
-                            continue;
                         if (fig->person[dt.index].hp <= runhp)
                             break;
                         if (fig->person[dt.index].flags & FL_PANICED) {


### PR DESCRIPTION
https://bugs.eressea.de/view.php?id=1596
remove an unnecessary (and wrong) check.