### PR TITLE
bug 2073: duplicate message sections in the report

### DIFF
--- a/src/creport.c
+++ b/src/creport.c
@@ -1442,11 +1442,10 @@ static void cr_output_region(FILE * F, report_context * ctx, seen_region * sr)
             }
         }
         if (sr->mode == see_unit || sr->mode == see_travel) {
+            message_list *mlist = r_getmessages(r, f);
             cr_output_messages(F, r->msgs, f);
-            {
-                message_list *mlist = r_getmessages(r, f);
-                if (mlist)
-                    cr_output_messages(F, mlist, f);
+            if (mlist) {
+                cr_output_messages(F, mlist, f);
             }
         }
         /* buildings */

--- a/src/kernel/messages.c
+++ b/src/kernel/messages.c
@@ -312,3 +312,22 @@ message *add_message(message_list ** pm, message * m)
     }
     return m;
 }
+
+struct mlist ** merge_messages(message_list *mlist, message_list *append) {
+    struct mlist **split = 0;
+    assert(mlist);
+    if (append) {
+        split = mlist->end;
+        *split = append->begin;
+        mlist->end = append->end;
+    }
+    return split;
+}
+
+void split_messages(message_list *mlist, struct mlist **split) {
+    assert(mlist);
+    if (split) {
+        *split = 0;
+        mlist->end = split;
+    }
+}

--- a/src/kernel/messages.h
+++ b/src/kernel/messages.h
@@ -54,6 +54,9 @@ extern "C" {
     void addmessage(struct region *r, struct faction *f, const char *s,
         msg_t mtype, int level);
 
+    struct mlist ** merge_messages(message_list *mlist, message_list *append);
+    void split_messages(message_list *mlist, struct mlist **split);
+
 #define ADDMSG(msgs, mcreate) { message * m = mcreate; if (m) { assert(m->refcount>=1); add_message(msgs, m); msg_release(m); } }
 
     void syntax_error(const struct unit *u, struct order *ord);

--- a/src/kernel/messages.test.c
+++ b/src/kernel/messages.test.c
@@ -36,9 +36,31 @@ void test_message(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_merge_split(CuTest *tc) {
+    message_list *mlist = 0, *append = 0;
+    struct mlist **split;
+    message_type *mtype = mt_new("custom", NULL);
+
+    mt_register(mtype);
+    add_message(&mlist, msg_message(mtype->name, ""));
+    add_message(&append, msg_message(mtype->name, ""));
+
+    CuAssertPtrEquals(tc, 0, mlist->begin->next);
+    CuAssertPtrEquals(tc, &mlist->begin->next, mlist->end);
+    split = merge_messages(mlist, append);
+    CuAssertPtrNotNull(tc, split);
+    CuAssertPtrEquals(tc, &mlist->begin->next, split);
+    CuAssertPtrEquals(tc, append->end, mlist->end);
+    CuAssertPtrNotNull(tc, mlist->begin->next);
+    CuAssertPtrEquals(tc, append->begin, mlist->begin->next);
+    split_messages(mlist, split);
+    CuAssertPtrEquals(tc, 0, mlist->begin->next);
+}
+
 CuSuite *get_messages_suite(void) {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_missing_message);
+    SUITE_ADD_TEST(suite, test_merge_split);
     SUITE_ADD_TEST(suite, test_message);
     return suite;
 }

--- a/src/report.c
+++ b/src/report.c
@@ -2335,9 +2335,14 @@ const char *charset)
         if (sr->mode == see_unit || sr->mode == see_travel) {
             // TODO: Bug 2073
             message_list *mlist = r_getmessages(r, f);
-            rp_messages(out, r->msgs, f, 0, true);
-            if (mlist)
+            if (mlist) {
+                struct mlist **split = merge_messages(mlist, r->msgs);
                 rp_messages(out, mlist, f, 0, true);
+                split_messages(mlist, split);
+            }
+            else {
+                rp_messages(out, r->msgs, f, 0, true);
+            }
         }
 
         /* report all units. they are pre-sorted in an efficient manner */


### PR DESCRIPTION
Merge region messages and individual messages before writing them into the report.
This fixes https://bugs.eressea.de/view.php?id=2073
