### PR TITLE
Bug 2007: show battles in final report

### DIFF
--- a/src/kernel/faction.c
+++ b/src/kernel/faction.c
@@ -310,14 +310,6 @@ void destroyfaction(faction * f)
         free(f->spellbook);
         f->spellbook = 0;
     }
-    while (f->battles) {
-        struct bmsg *bm = f->battles;
-        f->battles = bm->next;
-        if (bm->msgs) {
-            free_messagelist(bm->msgs);
-        }
-        free(bm);
-    }
 
     while (u) {
         /* give away your stuff, make zombies if you cannot (quest items) */


### PR DESCRIPTION
Do not remove battles from dead faction before writing the report, so the player knows what killed them.