### PR TITLE
refactoring: wrptr takes an int, not a size_t

### DIFF
--- a/s/travis-build
+++ b/s/travis-build
@@ -10,6 +10,7 @@ $BUILD/iniparser/inifile eressea.ini add lua:paths lunit:scripts
 fi
 }
 
+set -e
 [ -z $BUILD ] && BUILD=Debug ; export BUILD
 s/cmake-init
 s/build

--- a/src/battle.c
+++ b/src/battle.c
@@ -2972,10 +2972,10 @@ static void print_header(battle * b)
             for (df = s->fighters; df; df = df->next) {
                 if (is_attacker(df)) {
                     if (first) {
-                        bufp = STRLCPY(bufp, ", ", &size, "print_header");
+                        bufp = STRLCPY(bufp, ", ", size);
                     }
                     if (lastf) {
-                        bufp = STRLCPY(bufp, lastf, &size, "print_header");
+                        bufp = STRLCPY(bufp, lastf, size);
                         first = true;
                     }
                     if (seematrix(f, s))
@@ -2987,12 +2987,12 @@ static void print_header(battle * b)
             }
         }
         if (first) {
-            bufp = STRLCPY(bufp, " ", &size, "print_header");
-            bufp = STRLCPY(bufp, LOC(f->locale, "and"), &size, "print_header");
-            bufp = STRLCPY(bufp, " ", &size, "print_header");
+            bufp = STRLCPY(bufp, " ", size);
+            bufp = STRLCPY(bufp, LOC(f->locale, "and"), size);
+            bufp = STRLCPY(bufp, " ", size);
         }
         if (lastf) {
-            bufp = STRLCPY(bufp, lastf, &size, "print_header");
+            bufp = STRLCPY(bufp, lastf, size);
         }
 
         m = msg_message("battle::starters", "factions", zText);
@@ -3723,7 +3723,6 @@ static int battle_report(battle * b)
         faction *fac = bf->faction;
         char buf[32 * MAXSIDES];
         char *bufp = buf;
-        size_t bytes;
         size_t size = sizeof(buf) - 1;
         message *m;
 
@@ -3746,34 +3745,24 @@ static int battle_report(battle * b)
                 char buffer[32];
 
                 if (komma) {
-                    bytes = strlcpy(bufp, ", ", size);
-                    if (wrptr(&bufp, &size, bytes) != 0)
-                        WARN_STATIC_BUFFER();
+                    bufp = STRLCPY(bufp, ", ", size);
                 }
                 slprintf(buffer, sizeof(buffer), "%s %2d(%s): ",
                     loc_army, army_index(s), abbrev);
-
-                bytes = strlcpy(bufp, buffer, size);
-                if (wrptr(&bufp, &size, bytes) != 0)
-                    WARN_STATIC_BUFFER();
+                
+                bufp = STRLCPY(bufp, buffer, size);
 
                 for (r = FIGHT_ROW; r != NUMROWS; ++r) {
                     if (alive[r]) {
                         if (l != FIGHT_ROW) {
-                            bytes = strlcpy(bufp, "+", size);
-                            if (wrptr(&bufp, &size, bytes) != 0)
-                                WARN_STATIC_BUFFER();
+                            bufp = STRLCPY(bufp, "+", size);
                         }
                         while (k--) {
-                            bytes = strlcpy(bufp, "0+", size);
-                            if (wrptr(&bufp, &size, bytes) != 0)
-                                WARN_STATIC_BUFFER();
+                            bufp = STRLCPY(bufp, "0+", size);
                         }
                         sprintf(buffer, "%d", alive[r]);
-
-                        bytes = strlcpy(bufp, buffer, size);
-                        if (wrptr(&bufp, &size, bytes) != 0)
-                            WARN_STATIC_BUFFER();
+                        
+                        bufp = STRLCPY(bufp, buffer, size);
 
                         k = 0;
                         l = r + 1;

--- a/src/battle.c
+++ b/src/battle.c
@@ -2966,21 +2966,16 @@ static void print_header(battle * b)
         side *s;
         char *bufp = zText;
         size_t size = sizeof(zText) - 1;
-        size_t bytes;
 
         for (s = b->sides; s != b->sides + b->nsides; ++s) {
             fighter *df;
             for (df = s->fighters; df; df = df->next) {
                 if (is_attacker(df)) {
                     if (first) {
-                        bytes = strlcpy(bufp, ", ", size);
-                        if (wrptr(&bufp, &size, bytes) != 0)
-                            WARN_STATIC_BUFFER();
+                        bufp = STRLCPY(bufp, ", ", &size, "print_header");
                     }
                     if (lastf) {
-                        bytes = strlcpy(bufp, (const char *)lastf, size);
-                        if (wrptr(&bufp, &size, bytes) != 0)
-                            WARN_STATIC_BUFFER();
+                        bufp = STRLCPY(bufp, lastf, &size, "print_header");
                         first = true;
                     }
                     if (seematrix(f, s))
@@ -2992,20 +2987,12 @@ static void print_header(battle * b)
             }
         }
         if (first) {
-            bytes = strlcpy(bufp, " ", size);
-            if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
-            bytes = strlcpy(bufp, (const char *)LOC(f->locale, "and"), size);
-            if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
-            bytes = strlcpy(bufp, " ", size);
-            if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
+            bufp = STRLCPY(bufp, " ", &size, "print_header");
+            bufp = STRLCPY(bufp, LOC(f->locale, "and"), &size, "print_header");
+            bufp = STRLCPY(bufp, " ", &size, "print_header");
         }
         if (lastf) {
-            bytes = strlcpy(bufp, (const char *)lastf, size);
-            if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
+            bufp = STRLCPY(bufp, lastf, &size, "print_header");
         }
 
         m = msg_message("battle::starters", "factions", zText);

--- a/src/economy.test.c
+++ b/src/economy.test.c
@@ -142,10 +142,8 @@ static struct unit *create_recruiter(void) {
 static void test_heroes_dont_recruit(CuTest * tc) {
     unit *u;
     order *ord;
-    const message_type *msg_types[1];
 
     test_cleanup();
-    msg_types[0] = register_msg("error_herorecruit", 3, "unit:unit", "region:region", "command:order");
 
     u = create_recruiter();
     fset(u, UFL_HERO);
@@ -155,7 +153,7 @@ static void test_heroes_dont_recruit(CuTest * tc) {
     economics(u->region);
 
     CuAssertIntEquals(tc, 1, u->number);
-    assert_messages(tc, u->faction->msgs->begin, msg_types, 1, true, 0);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "error_herorecruit"));
 
     test_cleanup();
 }

--- a/src/kernel/config.c
+++ b/src/kernel/config.c
@@ -1676,6 +1676,7 @@ void attrib_init(void)
 void kernel_init(void)
 {
     register_reports();
+    mt_clear();
     if (!mt_find("missing_message")) {
         mt_register(mt_new_va("missing_message", "name:string", 0));
         mt_register(mt_new_va("missing_feedback", "unit:unit", "region:region", "command:order", "name:string", 0));

--- a/src/kernel/messages.test.c
+++ b/src/kernel/messages.test.c
@@ -17,6 +17,7 @@ void test_message(CuTest *tc) {
     message *msg;
     message_type *mtype = mt_new("custom", NULL);
 
+    test_cleanup();
     mt_register(mtype);
     CuAssertPtrEquals(tc, mtype, (void *)mt_find("custom"));
     CuAssertIntEquals(tc, 0, mtype->nparameters);
@@ -41,6 +42,7 @@ static void test_merge_split(CuTest *tc) {
     struct mlist **split;
     message_type *mtype = mt_new("custom", NULL);
 
+    test_cleanup();
     mt_register(mtype);
     add_message(&mlist, msg_message(mtype->name, ""));
     add_message(&append, msg_message(mtype->name, ""));
@@ -55,6 +57,7 @@ static void test_merge_split(CuTest *tc) {
     CuAssertPtrEquals(tc, append->begin, mlist->begin->next);
     split_messages(mlist, split);
     CuAssertPtrEquals(tc, 0, mlist->begin->next);
+    test_cleanup();
 }
 
 CuSuite *get_messages_suite(void) {

--- a/src/kernel/ship.test.c
+++ b/src/kernel/ship.test.c
@@ -521,12 +521,10 @@ static void test_shipspeed_damage(CuTest *tc) {
 static void test_shipspeed(CuTest *tc) {
     ship *sh;
     const ship_type *stype;
-    region *r;
     unit *cap, *crew;
 
     test_cleanup();
     sh = setup_ship();
-    r = sh->region;
     stype = sh->type;
 
     CuAssertIntEquals_Msg(tc, "ship without a captain cannot move", 0, shipspeed(sh, NULL));

--- a/src/laws.c
+++ b/src/laws.c
@@ -2320,7 +2320,8 @@ static bool display_race(faction * f, unit * u, const race * rc)
     name = rc_name_s(rc, NAME_SINGULAR);
 
     bytes = slprintf(bufp, size, "%s: ", LOC(f->locale, name));
-    if (wrptr(&bufp, &size, bytes) != 0)
+    assert(bytes <= INT_MAX);
+    if (wrptr(&bufp, &size, (int)bytes) != 0)
         WARN_STATIC_BUFFER();
 
     key = mkname("raceinfo", rc->_name);
@@ -2329,36 +2330,38 @@ static bool display_race(faction * f, unit * u, const race * rc)
         info = LOC(f->locale, mkname("raceinfo", "no_info"));
     }
 
-    bytes = strlcpy(bufp, info, size);
-    if (wrptr(&bufp, &size, bytes) != 0)
-        WARN_STATIC_BUFFER();
+    bufp = STRLCPY(bufp, info, &size, "display_race");
 
     /* hp_p : Trefferpunkte */
     bytes =
         slprintf(bufp, size, " %d %s", rc->hitpoints, LOC(f->locale,
         "stat_hitpoints"));
-    if (wrptr(&bufp, &size, bytes) != 0)
+    assert(bytes <= INT_MAX);
+    if (wrptr(&bufp, &size, (int)bytes) != 0)
         WARN_STATIC_BUFFER();
 
     /* b_attacke : Angriff */
     bytes =
         slprintf(bufp, size, ", %s: %d", LOC(f->locale, "stat_attack"),
         (rc->at_default + rc->at_bonus));
-    if (wrptr(&bufp, &size, bytes) != 0)
+    assert(bytes <= INT_MAX);
+    if (wrptr(&bufp, &size, (int)bytes) != 0)
         WARN_STATIC_BUFFER();
 
     /* b_defense : Verteidigung */
     bytes =
         slprintf(bufp, size, ", %s: %d", LOC(f->locale, "stat_defense"),
         (rc->df_default + rc->df_bonus));
-    if (wrptr(&bufp, &size, bytes) != 0)
+    assert(bytes <= INT_MAX);
+    if (wrptr(&bufp, &size, (int)bytes) != 0)
         WARN_STATIC_BUFFER();
 
     /* b_armor : Rüstung */
     if (rc->armor > 0) {
         bytes =
             slprintf(bufp, size, ", %s: %d", LOC(f->locale, "stat_armor"), rc->armor);
-        if (wrptr(&bufp, &size, bytes) != 0)
+        assert(bytes <= INT_MAX);
+        if (wrptr(&bufp, &size, (int)bytes) != 0)
             WARN_STATIC_BUFFER();
     }
 
@@ -2377,30 +2380,23 @@ static bool display_race(faction * f, unit * u, const race * rc)
         }
     }
     if (rc->battle_flags & BF_EQUIPMENT) {
-        bytes = (size_t)_snprintf(bufp, size, " %s", LOC(f->locale, "stat_equipment"));
-        if (wrptr(&bufp, &size, bytes) != 0)
+        if (wrptr(&bufp, &size, _snprintf(bufp, size, " %s", LOC(f->locale, "stat_equipment"))) != 0)
             WARN_STATIC_BUFFER();
     }
     if (rc->battle_flags & BF_RES_PIERCE) {
-        bytes = (size_t)_snprintf(bufp, size, " %s", LOC(f->locale, "stat_pierce"));
-        if (wrptr(&bufp, &size, bytes) != 0)
+        if (wrptr(&bufp, &size, _snprintf(bufp, size, " %s", LOC(f->locale, "stat_pierce"))) != 0)
             WARN_STATIC_BUFFER();
     }
     if (rc->battle_flags & BF_RES_CUT) {
-        bytes = (size_t)_snprintf(bufp, size, " %s", LOC(f->locale, "stat_cut"));
-        if (wrptr(&bufp, &size, bytes) != 0)
+        if (wrptr(&bufp, &size, _snprintf(bufp, size, " %s", LOC(f->locale, "stat_cut"))) != 0)
             WARN_STATIC_BUFFER();
     }
     if (rc->battle_flags & BF_RES_BASH) {
-        bytes = (size_t)_snprintf(bufp, size, " %s", LOC(f->locale, "stat_bash"));
-        if (wrptr(&bufp, &size, bytes) != 0)
+        if (wrptr(&bufp, &size, _snprintf(bufp, size, " %s", LOC(f->locale, "stat_bash"))) != 0)
             WARN_STATIC_BUFFER();
     }
 
-    bytes =
-       (size_t)_snprintf(bufp, size, " %d %s", at_count, LOC(f->locale,
-        (at_count == 1) ? "stat_attack" : "stat_attacks"));
-    if (wrptr(&bufp, &size, bytes) != 0)
+    if (wrptr(&bufp, &size, _snprintf(bufp, size, " %d %s", at_count, LOC(f->locale, (at_count == 1) ? "stat_attack" : "stat_attacks"))) != 0)
         WARN_STATIC_BUFFER();
 
     for (a = 0; a < RACE_ATTACKS; a++) {
@@ -2439,7 +2435,8 @@ static bool display_race(faction * f, unit * u, const race * rc)
                 bytes = 0;
             }
 
-            if (bytes && wrptr(&bufp, &size, bytes) != 0)
+            assert(bytes <= INT_MAX);
+            if (bytes && wrptr(&bufp, &size, (int)bytes) != 0)
                 WARN_STATIC_BUFFER();
         }
     }

--- a/src/laws.c
+++ b/src/laws.c
@@ -2330,7 +2330,7 @@ static bool display_race(faction * f, unit * u, const race * rc)
         info = LOC(f->locale, mkname("raceinfo", "no_info"));
     }
 
-    bufp = STRLCPY(bufp, info, &size, "display_race");
+    bufp = STRLCPY(bufp, info, size);
 
     /* hp_p : Trefferpunkte */
     bytes =
@@ -2402,11 +2402,9 @@ static bool display_race(faction * f, unit * u, const race * rc)
     for (a = 0; a < RACE_ATTACKS; a++) {
         if (rc->attack[a].type != AT_NONE) {
             if (a != 0)
-                bytes = strlcpy(bufp, ", ", size);
+                bufp = STRLCPY(bufp, ", ", size);
             else
-                bytes = strlcpy(bufp, ": ", size);
-            if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
+                bufp = STRLCPY(bufp, ": ", size);
 
             switch (rc->attack[a].type) {
             case AT_STANDARD:

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -745,13 +745,9 @@ static void test_peasant_luck_effect(CuTest *tc) {
 
 static void test_luck_message(CuTest *tc) {
     region* r;
-    const message_type *msg_types[1];
-
     test_cleanup();
     r = test_create_region(0, 0, NULL);
     rsetpeasants(r, 1);
-
-    msg_types[0] = register_msg("peasantluck_success", 1, "births:int");
 
     demographics();
 
@@ -764,7 +760,7 @@ static void test_luck_message(CuTest *tc) {
 
     demographics();
 
-    assert_messages(tc, r->msgs->begin, msg_types, 1, true, 0);
+    CuAssertPtrNotNull(tc, test_find_messagetype(r->msgs, "peasantluck_success"));
 
     test_cleanup();
 }

--- a/src/move.c
+++ b/src/move.c
@@ -77,6 +77,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 int *storms;
 

--- a/src/move.c
+++ b/src/move.c
@@ -1131,7 +1131,6 @@ static const char *shortdirections[MAXDIRECTIONS] = {
 
 static void cycle_route(order * ord, unit * u, int gereist)
 {
-    size_t bytes;
     int cm = 0;
     char tail[1024], *bufp = tail;
     char neworder[2048];
@@ -1172,25 +1171,17 @@ static void cycle_route(order * ord, unit * u, int gereist)
             if (!pause) {
                 const char *loc = LOC(lang, shortdirections[d]);
                 if (bufp != tail) {
-                    bytes = strlcpy(bufp, " ", size);
-                    if (wrptr(&bufp, &size, bytes) != 0)
-                        WARN_STATIC_BUFFER();
+                    bufp = STRLCPY(bufp, " ", &size, "cycle_route");
                 }
-                bytes = strlcpy(bufp, loc, size);
-                if (wrptr(&bufp, &size, bytes) != 0)
-                    WARN_STATIC_BUFFER();
+                bufp = STRLCPY(bufp, loc, &size, "cycle_route");
             }
         }
         else if (strlen(neworder) > sizeof(neworder) / 2)
             break;
         else if (cm == gereist && !paused && pause) {
             const char *loc = LOC(lang, parameters[P_PAUSE]);
-            bytes = strlcpy(bufp, " ", size);
-            if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
-            bytes = strlcpy(bufp, loc, size);
-            if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
+            bufp = STRLCPY(bufp, " ", &size, "cycle_route");
+            bufp = STRLCPY(bufp, loc, &size, "cycle_route");
             paused = true;
         }
         else if (pause) {
@@ -2568,12 +2559,9 @@ static int hunt(unit * u, order * ord)
     }
     rc = rconnect(rc, dir);
     while (moves < speed && (dir = hunted_dir(rc->attribs, id)) != NODIRECTION) {
-        bytes = strlcpy(bufp, " ", size);
-        if (wrptr(&bufp, &size, bytes) != 0)
-            WARN_STATIC_BUFFER();
-        bytes = strlcpy(bufp, LOC(u->faction->locale, directions[dir]), size);
-        if (wrptr(&bufp, &size, bytes) != 0)
-            WARN_STATIC_BUFFER();
+        const char *loc = LOC(u->faction->locale, directions[dir]);
+        bufp = STRLCPY(bufp, " ", &size, "hunt");
+        bufp = STRLCPY(bufp, loc, &size, "hunt");
         moves++;
         rc = rconnect(rc, dir);
     }

--- a/src/move.c
+++ b/src/move.c
@@ -2543,7 +2543,8 @@ static int hunt(unit * u, order * ord)
 
     bufp = command;
     bytes = slprintf(bufp, size, "%s %s", LOC(u->faction->locale, keyword(K_MOVE)), LOC(u->faction->locale, directions[dir]));
-    if (wrptr(&bufp, &size, bytes) != 0)
+    assert(bytes <= INT_MAX);
+    if (wrptr(&bufp, &size, (int)bytes) != 0)
         WARN_STATIC_BUFFER();
 
     moves = 1;

--- a/src/move.c
+++ b/src/move.c
@@ -1172,17 +1172,17 @@ static void cycle_route(order * ord, unit * u, int gereist)
             if (!pause) {
                 const char *loc = LOC(lang, shortdirections[d]);
                 if (bufp != tail) {
-                    bufp = STRLCPY(bufp, " ", &size, "cycle_route");
+                    bufp = STRLCPY_EX(bufp, " ", &size, "cycle_route");
                 }
-                bufp = STRLCPY(bufp, loc, &size, "cycle_route");
+                bufp = STRLCPY_EX(bufp, loc, &size, "cycle_route");
             }
         }
         else if (strlen(neworder) > sizeof(neworder) / 2)
             break;
         else if (cm == gereist && !paused && pause) {
             const char *loc = LOC(lang, parameters[P_PAUSE]);
-            bufp = STRLCPY(bufp, " ", &size, "cycle_route");
-            bufp = STRLCPY(bufp, loc, &size, "cycle_route");
+            bufp = STRLCPY_EX(bufp, " ", &size, "cycle_route");
+            bufp = STRLCPY_EX(bufp, loc, &size, "cycle_route");
             paused = true;
         }
         else if (pause) {
@@ -2562,8 +2562,8 @@ static int hunt(unit * u, order * ord)
     rc = rconnect(rc, dir);
     while (moves < speed && (dir = hunted_dir(rc->attribs, id)) != NODIRECTION) {
         const char *loc = LOC(u->faction->locale, directions[dir]);
-        bufp = STRLCPY(bufp, " ", &size, "hunt");
-        bufp = STRLCPY(bufp, loc, &size, "hunt");
+        bufp = STRLCPY_EX(bufp, " ", &size, "hunt");
+        bufp = STRLCPY_EX(bufp, loc, &size, "hunt");
         moves++;
         rc = rconnect(rc, dir);
     }

--- a/src/report.c
+++ b/src/report.c
@@ -100,6 +100,17 @@ extern int *storms;
 extern int weeks_per_month;
 extern int months_per_year;
 
+static void check_errno(const char * file, int line) {
+    if (errno) {
+        char zText[64];
+        sprintf(zText, "error %d during report at %s:%d", errno, file, line);
+        perror(zText);
+        errno = 0;
+    }
+}
+
+#define CHECK_ERRNO() check_errno(__FILE__, __LINE__)
+
 static char *gamedate_season(const struct locale *lang)
 {
     static char buf[256]; // FIXME: static return value
@@ -1396,14 +1407,17 @@ static void durchreisende(stream *out, const region * r, const faction * f)
             }
         }
         if (size > 0) {
+            CHECK_ERRNO();
             if (maxtravel == 1) {
                 bytes = _snprintf(bufp, size, " %s", LOC(f->locale, "has_moved_one"));
             }
             else {
                 bytes = _snprintf(bufp, size, " %s", LOC(f->locale, "has_moved_many"));
             }
+            CHECK_ERRNO();
             if (wrptr(&bufp, &size, bytes) != 0)
-                WARN_STATIC_BUFFER();
+                WARN_STATIC_BUFFER_EX("durchreisende");
+            CHECK_ERRNO();
         }
         *bufp = 0;
         paragraph(out, buf, 0, 0, 0);
@@ -2206,6 +2220,7 @@ const char *charset)
     }
 
     ch = 0;
+    CHECK_ERRNO();
     for (a = a_find(f->attribs, &at_showitem); a && a->type == &at_showitem;
         a = a->next) {
         const potion_type *ptype =
@@ -2258,6 +2273,7 @@ const char *charset)
         }
     }
     newline(out);
+    CHECK_ERRNO();
     centre(out, LOC(f->locale, "nr_alliances"), false);
     newline(out);
 
@@ -2265,6 +2281,7 @@ const char *charset)
 
     rpline(out);
 
+    CHECK_ERRNO();
     anyunits = 0;
 
     for (r = ctx->first; sr == NULL && r != ctx->last; r = r->next) {
@@ -2389,6 +2406,7 @@ const char *charset)
 
         newline(out);
         rpline(out);
+        CHECK_ERRNO();
     }
     if (!is_monsters(f)) {
         if (!anyunits) {
@@ -2400,6 +2418,7 @@ const char *charset)
         }
     }
     fstream_done(&strm);
+    CHECK_ERRNO();
     return 0;
 }
 

--- a/src/spells.c
+++ b/src/spells.c
@@ -604,13 +604,15 @@ static int sp_summon_familiar(castorder * co)
                 else {
                     bytes = strlcpy(bufp, (const char *)", ", size);
                 }
-                if (wrptr(&bufp, &size, bytes) != 0)
+                assert(bytes <= INT_MAX);
+                if (wrptr(&bufp, &size, (int)bytes) != 0)
                     WARN_STATIC_BUFFER();
             }
             bytes =
                 strlcpy(bufp, (const char *)skillname((skill_t)sk, mage->faction->locale),
                 size);
-            if (wrptr(&bufp, &size, bytes) != 0)
+            assert(bytes <= INT_MAX);
+            if (wrptr(&bufp, &size, (int)bytes) != 0)
                 WARN_STATIC_BUFFER();
         }
     }

--- a/src/spy.test.c
+++ b/src/spy.test.c
@@ -24,20 +24,10 @@
 
 #include <CuTest.h>
 
-typedef enum {
-    M_BASE,
-    M_MAGE,
-    M_SKILLS,
-    M_FACTION,
-    M_ITEMS,
-    NUM_TYPES
-} m_type;
-
 typedef struct {
     region *r;
     unit *spy;
     unit *victim;
-    const message_type *msg_types[NUM_TYPES];
 } spy_fixture;
 
 static void setup_spy(spy_fixture *fix) {
@@ -45,12 +35,6 @@ static void setup_spy(spy_fixture *fix) {
     fix->r = test_create_region(0, 0, NULL);
     fix->spy = test_create_unit(test_create_faction(NULL), fix->r);
     fix->victim = test_create_unit(test_create_faction(NULL), fix->r);
-    fix->msg_types[M_BASE] = register_msg("spyreport", 3, "spy:unit", "target:unit", "status:string");
-    fix->msg_types[M_MAGE] = register_msg("spyreport_mage", 3, "spy:unit", "target:unit", "type:string");
-    fix->msg_types[M_SKILLS] = register_msg("spyreport_skills", 3, "spy:unit", "target:unit", "skills:string");
-    fix->msg_types[M_FACTION] = register_msg("spyreport_faction", 3, "spy:unit", "target:unit", "faction:faction");
-    fix->msg_types[M_ITEMS] = register_msg("spyreport_items", 3, "spy:unit", "target:unit", "items:items");
-
 }
 
 static void test_simple_spy_message(CuTest *tc) {
@@ -60,8 +44,7 @@ static void test_simple_spy_message(CuTest *tc) {
 
     spy_message(0, fix.spy, fix.victim);
 
-    assert_messages(tc, fix.spy->faction->msgs->begin, fix.msg_types, 1, true, M_BASE);
-
+    CuAssertPtrNotNull(tc, test_find_messagetype(fix.spy->faction->msgs, "spyreport"));
 
     test_cleanup();
 }
@@ -92,12 +75,11 @@ static void test_all_spy_message(CuTest *tc) {
 
     spy_message(99, fix.spy, fix.victim);
 
-    assert_messages(tc, fix.spy->faction->msgs->begin, fix.msg_types, 5, true,
-        M_BASE,
-        M_MAGE,
-        M_FACTION,
-        M_SKILLS,
-        M_ITEMS);
+    CuAssertPtrNotNull(tc, test_find_messagetype(fix.spy->faction->msgs, "spyreport"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(fix.spy->faction->msgs, "spyreport_mage"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(fix.spy->faction->msgs, "spyreport_skills"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(fix.spy->faction->msgs, "spyreport_faction"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(fix.spy->faction->msgs, "spyreport_items"));
 
     test_cleanup();
 }

--- a/src/tests.h
+++ b/src/tests.h
@@ -44,10 +44,6 @@ extern "C" {
     struct message * test_find_messagetype(struct message_list *msgs, const char *name);
     struct message * test_get_last_message(struct message_list *mlist);
 
-    const struct message_type *register_msg(const char *type, int n_param, ...);
-    void assert_messages(struct CuTest * tc, struct mlist *msglist, const struct message_type **types,
-        int num_msgs, bool exact_match, ...);
-
     void disabled_test(void *suite, void (*)(struct CuTest *), const char *name);
 
 #define DISABLE_TEST(SUITE, TEST) disabled_test(SUITE, TEST, #TEST)

--- a/src/util/bsdstring.c
+++ b/src/util/bsdstring.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <stdarg.h>
+#include <limits.h>
 
 #include "bsdstring.h"
 #include "log.h"
@@ -66,8 +67,14 @@ char * strlcpy_w(char *dst, const char *src, size_t *siz, const char *err, const
 {
     size_t bytes = strlcpy(dst, src, *siz);
     char * buf = dst;
-    if (wrptr(&buf, siz, bytes) != 0)
-        log_warning("%s: static buffer too small in %s:%d\n", err, file, line);
+    assert(bytes <= INT_MAX);
+    if (wrptr(&buf, siz, (int)bytes) != 0) {
+        if (err) {
+            log_warning("%s: static buffer too small in %s:%d\n", err, file, line);
+        } else {
+            log_warning("static buffer too small in %s:%d\n", file, line);
+        }
+    }
     return buf;
 }
 

--- a/src/util/bsdstring.c
+++ b/src/util/bsdstring.c
@@ -7,8 +7,18 @@
 
 #include "bsdstring.h"
 
-int wrptr(char **ptr, size_t * size, size_t bytes)
+int wrptr(char **ptr, size_t * size, int result)
 {
+    size_t bytes = (size_t)result;
+    if (result < 0) {
+        // _snprintf buffer was too small
+        if (*size > 0) {
+            **ptr = 0;
+            *size = 0;
+        }
+        errno = 0;
+        return ERANGE;
+    }
     if (bytes == 0) {
         return 0;
     }

--- a/src/util/bsdstring.c
+++ b/src/util/bsdstring.c
@@ -6,6 +6,7 @@
 #include <stdarg.h>
 
 #include "bsdstring.h"
+#include "log.h"
 
 int wrptr(char **ptr, size_t * size, int result)
 {
@@ -60,6 +61,17 @@ size_t strlcpy(char *dst, const char *src, size_t siz)
     return (s - src - 1);         /* count does not include NUL */
 }
 #endif
+
+char * strlcpy_w(char *dst, const char *src, size_t *siz, const char *err, const char *file, int line)
+{
+    size_t bytes = strlcpy(dst, src, *siz);
+    char * buf = dst;
+    if (wrptr(&buf, siz, bytes) != 0)
+        log_warning("%s: static buffer too small in %s:%d\n", err, file, line);
+    return buf;
+}
+
+
 
 #ifndef HAVE_STRLCAT
 #define HAVE_STRLCAT

--- a/src/util/bsdstring.h
+++ b/src/util/bsdstring.h
@@ -20,6 +20,7 @@ size_t slprintf(char * dst, size_t size, const char * format, ...);
 #define WARN_STATIC_BUFFER_EX(foo) log_warning("%s: static buffer too small in %s:%d\n", (foo), __FILE__, __LINE__)
 #define WARN_STATIC_BUFFER() log_warning("static buffer too small in %s:%d\n", __FILE__, __LINE__)
 #define INFO_STATIC_BUFFER() log_info("static buffer too small in %s:%d\n", __FILE__, __LINE__)
-#define STRLCPY(dst, src, siz, err) strlcpy_w((dst), (src), (siz), (err), __FILE__, __LINE__)
+#define STRLCPY(dst, src, siz) strlcpy_w((dst), (src), &(siz), 0, __FILE__, __LINE__)
+#define STRLCPY_EX(dst, src, siz, err) strlcpy_w((dst), (src), (siz), (err), __FILE__, __LINE__)
 
 #endif

--- a/src/util/bsdstring.h
+++ b/src/util/bsdstring.h
@@ -2,7 +2,7 @@
 #define UTIL_BSDSTRING_H
 
 #include <stddef.h>
-extern int wrptr(char **ptr, size_t * size, size_t bytes);
+extern int wrptr(char **ptr, size_t * size, int bytes);
 
 #ifndef HAVE_STRLCPY
 extern size_t strlcpy(char *dst, const char *src, size_t siz);
@@ -16,6 +16,7 @@ extern size_t strlcat(char *dst, const char *src, size_t siz);
 extern size_t slprintf(char * dst, size_t size, const char * format, ...);
 #endif
 
+#define WARN_STATIC_BUFFER_EX(foo) log_warning("%s: static buffer too small in %s:%d\n", (foo), __FILE__, __LINE__)
 #define WARN_STATIC_BUFFER() log_warning("static buffer too small in %s:%d\n", __FILE__, __LINE__)
 #define INFO_STATIC_BUFFER() log_info("static buffer too small in %s:%d\n", __FILE__, __LINE__)
 

--- a/src/util/bsdstring.h
+++ b/src/util/bsdstring.h
@@ -2,22 +2,24 @@
 #define UTIL_BSDSTRING_H
 
 #include <stddef.h>
-extern int wrptr(char **ptr, size_t * size, int bytes);
+int wrptr(char **ptr, size_t * size, int bytes);
 
 #ifndef HAVE_STRLCPY
-extern size_t strlcpy(char *dst, const char *src, size_t siz);
+size_t strlcpy(char *dst, const char *src, size_t siz);
 #endif
+char * strlcpy_w(char *dst, const char *src, size_t *siz, const char *err, const char *file, int line);
 
 #ifndef HAVE_STRLCAT
-extern size_t strlcat(char *dst, const char *src, size_t siz);
+size_t strlcat(char *dst, const char *src, size_t siz);
 #endif
 
 #ifndef HAVE_SLPRINTF
-extern size_t slprintf(char * dst, size_t size, const char * format, ...);
+size_t slprintf(char * dst, size_t size, const char * format, ...);
 #endif
 
 #define WARN_STATIC_BUFFER_EX(foo) log_warning("%s: static buffer too small in %s:%d\n", (foo), __FILE__, __LINE__)
 #define WARN_STATIC_BUFFER() log_warning("static buffer too small in %s:%d\n", __FILE__, __LINE__)
 #define INFO_STATIC_BUFFER() log_info("static buffer too small in %s:%d\n", __FILE__, __LINE__)
+#define STRLCPY(dst, src, siz, err) strlcpy_w((dst), (src), (siz), (err), __FILE__, __LINE__)
 
 #endif

--- a/src/util/message.c
+++ b/src/util/message.c
@@ -32,6 +32,32 @@ const char *mt_name(const message_type * mtype)
     return mtype->name;
 }
 
+arg_type *argtypes = NULL;
+
+void
+register_argtype(const char *name, void(*free_arg) (variant),
+variant(*copy_arg) (variant), variant_type type)
+{
+    arg_type *atype = (arg_type *)malloc(sizeof(arg_type));
+    atype->name = name;
+    atype->next = argtypes;
+    atype->release = free_arg;
+    atype->copy = copy_arg;
+    atype->vtype = type;
+    argtypes = atype;
+}
+
+static arg_type *find_argtype(const char *name)
+{
+    arg_type *atype = argtypes;
+    while (atype != NULL) {
+        if (strcmp(atype->name, name) == 0)
+            return atype;
+        atype = atype->next;
+    }
+    return NULL;
+}
+
 message_type *mt_new(const char *name, const char *args[])
 {
     int i, nparameters = 0;
@@ -50,8 +76,8 @@ message_type *mt_new(const char *name, const char *args[])
     mtype->name = _strdup(name);
     mtype->nparameters = nparameters;
     if (nparameters > 0) {
-        mtype->pnames = (const char **)malloc(sizeof(char *) * nparameters);
-        mtype->types = (const arg_type **)malloc(sizeof(arg_type *) * nparameters);
+        mtype->pnames = (char **)malloc(sizeof(char *) * nparameters);
+        mtype->types = (arg_type **)malloc(sizeof(arg_type *) * nparameters);
     }
     else {
         mtype->pnames = NULL;
@@ -96,32 +122,6 @@ message_type *mt_new_va(const char *name, ...)
     return mt_new(name, args);
 }
 
-arg_type *argtypes = NULL;
-
-void
-register_argtype(const char *name, void(*free_arg) (variant),
-variant(*copy_arg) (variant), variant_type type)
-{
-    arg_type *atype = (arg_type *)malloc(sizeof(arg_type));
-    atype->name = name;
-    atype->next = argtypes;
-    atype->release = free_arg;
-    atype->copy = copy_arg;
-    atype->vtype = type;
-    argtypes = atype;
-}
-
-const arg_type *find_argtype(const char *name)
-{
-    arg_type *atype = argtypes;
-    while (atype != NULL) {
-        if (strcmp(atype->name, name) == 0)
-            return atype;
-        atype = atype->next;
-    }
-    return NULL;
-}
-
 static variant copy_arg(const arg_type * atype, variant data)
 {
     assert(atype != NULL);
@@ -160,6 +160,28 @@ message *msg_create(const struct message_type *mtype, variant args[])
 
 #define MT_MAXHASH 1021
 static quicklist *messagetypes[MT_MAXHASH];
+
+static void mt_free(void *val) {
+    message_type *mtype = (message_type *)val;
+    int i;
+    for (i = 0; i != mtype->nparameters; ++i) {
+        free(mtype->pnames[i]);
+    }
+    free(mtype->pnames);
+    free(mtype->types);
+    free(mtype->name);
+    free(mtype);
+}
+
+void mt_clear(void) {
+    int i;
+    for (i = 0; i != MT_MAXHASH; ++i) {
+        quicklist *ql = messagetypes[i];
+        ql_foreach(ql, mt_free);
+        ql_free(ql);
+        messagetypes[i] = 0;
+    }
+}
 
 const message_type *mt_find(const char *name)
 {

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -28,10 +28,10 @@ extern "C" {
 
     typedef struct message_type {
         unsigned int key;
-        const char *name;
+        char *name;
         int nparameters;
-        const char **pnames;
-        const struct arg_type **types;
+        char **pnames;
+        struct arg_type ** types;
     } message_type;
 
     typedef struct message {
@@ -40,8 +40,9 @@ extern "C" {
         int refcount;
     } message;
 
-    extern struct message_type *mt_new(const char *name, const char **args);
-    extern struct message_type *mt_new_va(const char *name, ...);
+    void mt_clear(void);
+    struct message_type *mt_new(const char *name, const char **args);
+    struct message_type *mt_new_va(const char *name, ...);
     /* mt_new("simple_sentence", "subject:string", "predicate:string",
      *        "object:string", "lang:locale", NULL); */
 
@@ -61,9 +62,8 @@ extern "C" {
 
     extern void register_argtype(const char *name, void(*free_arg) (variant),
         variant(*copy_arg) (variant), variant_type);
-    extern const struct arg_type *find_argtype(const char *name);
 
-    extern void(*msg_log_create) (const struct message * msg);
+    void(*msg_log_create) (const struct message * msg);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
centralizing static buffer warning logic into strlcpy_w (bsdstring.c), instead of it being littered all over the code.