### PR TITLE
cleanup: disabled tests, findunitr compexity

### DIFF
--- a/src/direction.test.c
+++ b/src/direction.test.c
@@ -57,15 +57,13 @@ static void test_get_direction_default(CuTest *tc) {
     CuAssertIntEquals(tc, D_EAST, get_direction("east", lang));
 }
 
-#define SUITE_DISABLE_TEST(suite, test) (void)test
-
 CuSuite *get_direction_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_init_direction);
     SUITE_ADD_TEST(suite, test_init_directions);
     SUITE_ADD_TEST(suite, test_finddirection);
-    SUITE_DISABLE_TEST(suite, test_get_direction_default);
+    DISABLE_TEST(suite, test_get_direction_default);
     return suite;
 }
 

--- a/src/economy.c
+++ b/src/economy.c
@@ -2640,8 +2640,9 @@ static void steal_cmd(unit * u, struct order *ord, request ** stealorders)
         return;
     }
     id = read_unitid(u->faction, r);
-    u2 = findunitr(r, id);
-
+    if (id>0) {
+        u2 = findunitr(r, id);
+    }
     if (u2 && u2->region == u->region) {
         f = u2->faction;
     }

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -97,25 +97,21 @@ attrib_type at_creator = {
     /* Rest ist NULL; temporaeres, nicht alterndes Attribut */
 };
 
-unit *findunitr(const region * r, int n)
-{
-    unit *u;
-
-    /* findunit regional! */
-
-    for (u = r->units; u; u = u->next)
-        if (u->no == n)
-            return u;
-
-    return 0;
-}
-
 unit *findunit(int n)
 {
     if (n <= 0) {
         return NULL;
     }
     return ufindhash(n);
+}
+
+unit *findunitr(const region * r, int n)
+{
+    unit *u;
+    /* findunit regional! */
+    assert(n>0);
+    u = ufindhash(n);
+    return (u && u->region==r)?u:0;
 }
 
 unit *findunitg(int n, const region * hint)

--- a/src/keyword.test.c
+++ b/src/keyword.test.c
@@ -93,8 +93,6 @@ static void test_get_shortest_match(CuTest *tc) {
     test_cleanup();
 }
 
-#define SUITE_DISABLE_TEST(suite, test) (void)test
-
 CuSuite *get_keyword_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -103,6 +101,6 @@ CuSuite *get_keyword_suite(void)
     SUITE_ADD_TEST(suite, test_init_keywords);
     SUITE_ADD_TEST(suite, test_findkeyword);
     SUITE_ADD_TEST(suite, test_get_shortest_match);
-    SUITE_DISABLE_TEST(suite, test_get_keyword_default);
+    DISABLE_TEST(suite, test_get_keyword_default);
     return suite;
 }

--- a/src/skill.test.c
+++ b/src/skill.test.c
@@ -43,15 +43,13 @@ static void test_get_skill_default(CuTest *tc) {
     CuAssertIntEquals(tc, SK_CROSSBOW, get_skill("crossbow", lang));
 }
 
-#define SUITE_DISABLE_TEST(suite, test) (void)test
-
 CuSuite *get_skill_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_init_skill);
     SUITE_ADD_TEST(suite, test_init_skills);
     SUITE_ADD_TEST(suite, test_get_skill);
-    SUITE_DISABLE_TEST(suite, test_get_skill_default);
+    DISABLE_TEST(suite, test_get_skill_default);
     return suite;
 }
 


### PR DESCRIPTION
* use DISABLED_TEST macro everywhere
* reduce theoretical complexity of findunitr to O(1)
