### PR TITLE
Bug/#2145

### DIFF
--- a/src/battle.c
+++ b/src/battle.c
@@ -1156,12 +1156,6 @@ terminate(troop dt, troop at, int type, const char *damage, bool missile)
     /* Momentan nur Trollgürtel und Werwolf-Eigenschaft */
     am = select_magicarmor(dt);
 
-    if (awtype && fval(awtype, WTF_ARMORPIERCING)) {
-        /* crossbows */
-        ar /= 2;
-        an /= 2;
-    }
-
     if (rule_armor < 0) {
         rule_armor = get_param_int(global.parameters, "rules.combat.nat_armor", 0);
     }
@@ -1178,6 +1172,12 @@ terminate(troop dt, troop at, int type, const char *damage, bool missile)
         /* use the higher value, add half the other value */
         ar = (ar > an) ? (ar + an / 2) : (an + ar / 2);
     }
+
+    if (awtype && fval(awtype, WTF_ARMORPIERCING)) {
+        /* crossbows */
+        ar /= 2;
+    }
+
     ar += am;
 
     if (type != AT_COMBATSPELL && type != AT_SPELL) {

--- a/src/battle.c
+++ b/src/battle.c
@@ -1156,13 +1156,11 @@ terminate(troop dt, troop at, int type, const char *damage, bool missile)
     /* Momentan nur Trollgürtel und Werwolf-Eigenschaft */
     am = select_magicarmor(dt);
 
-#if CHANGED_CROSSBOWS
     if (awtype && fval(awtype, WTF_ARMORPIERCING)) {
         /* crossbows */
         ar /= 2;
         an /= 2;
     }
-#endif
 
     if (rule_armor < 0) {
         rule_armor = get_param_int(global.parameters, "rules.combat.nat_armor", 0);

--- a/src/battle.test.c
+++ b/src/battle.test.c
@@ -204,71 +204,6 @@ static void test_building_defence_bonus(CuTest * tc)
     test_cleanup();
 }
 
-static void test_armor_penetration(CuTest * tc)
-{
-    faction* pAttackingFaction = NULL;
-    faction* pDefendingFaction_Human = NULL;
-    faction* pDefendingFaction_Demon = NULL;
-    unit* pAttackingUnit = NULL;
-    unit* pDefendingUnit = NULL;
-    fighter* pAttackingFighter = NULL;
-    fighter* pDefendingFighter = NULL;
-    troop attackingTroop;
-    troop defendingTroop;
-    side* pAttackingSide = NULL;
-    side* pDefendingSide = NULL;
-    region* pRegion = NULL;
-    battle* pBattle = NULL;
-
-    test_cleanup();
-    test_create_world();
-
-    resource_type* pResType_Crossbow = rt_get_or_create("crossbow");
-    item_type* pItemType_Crossbow = it_get_or_create(pResType_Crossbow);
-    (void)new_weapontype(pItemType_Crossbow, WTF_ARMORPIERCING, 0.0, NULL, 0, 0, 1, SK_CROSSBOW, 1);
-    item* pItem_Crossbow = i_new(pItemType_Crossbow, 1);
-
-    item_type* pItemType_Armor = it_get_or_create(rt_get_or_create("plate"));
-    /*armor_type* pArmorType = */new_armortype(pItemType_Armor, 0.0, 0.0, 5, ATF_NONE);
-
-    pRegion = findregion(0, 0);
-
-    pAttackingFaction = test_create_faction(NULL);
-    pDefendingFaction_Human = test_create_faction(rc_get_or_create("human"));
-    pDefendingFaction_Demon = test_create_faction(rc_get_or_create("demon"));
-
-    pAttackingUnit = test_create_unit(pAttackingFaction, pRegion);
-    scale_number(pAttackingUnit, 1);
-    set_level(pAttackingUnit, SK_CROSSBOW, 10);
-    pAttackingUnit->items = pItem_Crossbow;
-    
-
-    pDefendingUnit = test_create_unit(pDefendingFaction_Human, pRegion);
-    scale_number(pDefendingUnit, 1);
-    //i_change(&(pDefendingUnit->items), pItemType_Armor, 1);
-
-    pBattle = make_battle(pRegion);
-    pAttackingSide = make_side(pBattle, pAttackingFaction, NULL, 0, NULL);
-    pDefendingSide = make_side(pBattle, pDefendingFaction_Human, NULL, 0, NULL);
-
-    pAttackingFighter = make_fighter(pBattle, pAttackingUnit, pAttackingSide, false);
-    attackingTroop.fighter = pAttackingFighter;
-    attackingTroop.index = 0;
-
-    pDefendingFighter = make_fighter(pBattle, pDefendingUnit, pDefendingSide, false);
-    defendingTroop.fighter = pDefendingFighter;
-    defendingTroop.index = 0;
-
-    int initialHP = 10;
-    pDefendingUnit->hp = initialHP;
-
-    CuAssertTrue(tc, terminate(defendingTroop, attackingTroop, AT_STANDARD, "10", true));
-
-    CuAssertIntEquals(tc, initialHP - 10, pDefendingUnit->hp);
-
-    test_cleanup();
-}
-
 CuSuite *get_battle_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -277,6 +212,5 @@ CuSuite *get_battle_suite(void)
     SUITE_ADD_TEST(suite, test_attackers_get_no_building_bonus);
     SUITE_ADD_TEST(suite, test_building_bonus_respects_size);
     SUITE_ADD_TEST(suite, test_building_defence_bonus);
-	SUITE_ADD_TEST(suite, test_armor_penetration);
     return suite;
 }

--- a/src/battle.test.c
+++ b/src/battle.test.c
@@ -204,6 +204,71 @@ static void test_building_defence_bonus(CuTest * tc)
     test_cleanup();
 }
 
+static void test_armor_penetration(CuTest * tc)
+{
+    faction* pAttackingFaction = NULL;
+    faction* pDefendingFaction_Human = NULL;
+    faction* pDefendingFaction_Demon = NULL;
+    unit* pAttackingUnit = NULL;
+    unit* pDefendingUnit = NULL;
+    fighter* pAttackingFighter = NULL;
+    fighter* pDefendingFighter = NULL;
+    troop attackingTroop;
+    troop defendingTroop;
+    side* pAttackingSide = NULL;
+    side* pDefendingSide = NULL;
+    region* pRegion = NULL;
+    battle* pBattle = NULL;
+
+    test_cleanup();
+    test_create_world();
+
+    resource_type* pResType_Crossbow = rt_get_or_create("crossbow");
+    item_type* pItemType_Crossbow = it_get_or_create(pResType_Crossbow);
+    (void)new_weapontype(pItemType_Crossbow, WTF_ARMORPIERCING, 0.0, NULL, 0, 0, 1, SK_CROSSBOW, 1);
+    item* pItem_Crossbow = i_new(pItemType_Crossbow, 1);
+
+    item_type* pItemType_Armor = it_get_or_create(rt_get_or_create("plate"));
+    /*armor_type* pArmorType = */new_armortype(pItemType_Armor, 0.0, 0.0, 5, ATF_NONE);
+
+    pRegion = findregion(0, 0);
+
+    pAttackingFaction = test_create_faction(NULL);
+    pDefendingFaction_Human = test_create_faction(rc_get_or_create("human"));
+    pDefendingFaction_Demon = test_create_faction(rc_get_or_create("demon"));
+
+    pAttackingUnit = test_create_unit(pAttackingFaction, pRegion);
+    scale_number(pAttackingUnit, 1);
+    set_level(pAttackingUnit, SK_CROSSBOW, 10);
+    pAttackingUnit->items = pItem_Crossbow;
+    
+
+    pDefendingUnit = test_create_unit(pDefendingFaction_Human, pRegion);
+    scale_number(pDefendingUnit, 1);
+    //i_change(&(pDefendingUnit->items), pItemType_Armor, 1);
+
+    pBattle = make_battle(pRegion);
+    pAttackingSide = make_side(pBattle, pAttackingFaction, NULL, 0, NULL);
+    pDefendingSide = make_side(pBattle, pDefendingFaction_Human, NULL, 0, NULL);
+
+    pAttackingFighter = make_fighter(pBattle, pAttackingUnit, pAttackingSide, false);
+    attackingTroop.fighter = pAttackingFighter;
+    attackingTroop.index = 0;
+
+    pDefendingFighter = make_fighter(pBattle, pDefendingUnit, pDefendingSide, false);
+    defendingTroop.fighter = pDefendingFighter;
+    defendingTroop.index = 0;
+
+    int initialHP = 10;
+    pDefendingUnit->hp = initialHP;
+
+    CuAssertTrue(tc, terminate(defendingTroop, attackingTroop, AT_STANDARD, "10", true));
+
+    CuAssertIntEquals(tc, initialHP - 10, pDefendingUnit->hp);
+
+    test_cleanup();
+}
+
 CuSuite *get_battle_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -212,5 +277,6 @@ CuSuite *get_battle_suite(void)
     SUITE_ADD_TEST(suite, test_attackers_get_no_building_bonus);
     SUITE_ADD_TEST(suite, test_building_bonus_respects_size);
     SUITE_ADD_TEST(suite, test_building_defence_bonus);
+	SUITE_ADD_TEST(suite, test_armor_penetration);
     return suite;
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -37,6 +37,5 @@
  */
 #define MUSEUM_MODULE 1
 #define ARENA_MODULE 1
-#define CHANGED_CROSSBOWS 0     /* use the WTF_ARMORPIERCING flag */
 
 #undef REGIONOWNERS             /* (WIP) region-owner uses HELP_TRAVEL to control entry to region */


### PR DESCRIPTION
Bin @CTD1 Vorschlag gefolgt und habe die Anwendung des ArmorPiercing-Effekts hinter die Kumulierung der natürlichen Rüstung gesetzt, aber vor die Aufrechnung magischer Rüstung. So finde ich es spieltechnisch ordentlich.

P.S.: Den Test dafür habe ich verworfen, weil mich die Kampflogik moralisch gebrochen hat. ;) Aber wenn wer einen Tipp für mich hat, wie man in der Testumgebung einen Kampf zwischen zwei Personen mit Ausrüstung hochzieht, reiche ich das gern noch nach. Den letzten Stand meines Ansatzes findet man in den Commits.