### PR TITLE
bug/#2144

### DIFF
--- a/src/laws.c
+++ b/src/laws.c
@@ -2461,8 +2461,10 @@ static void reshow(unit * u, struct order *ord, const char *s, param_t p)
                         break;
                 }
                 else {
-                    if (display_item(u->faction, u, itype))
-                        break;
+                    if (!display_item(u->faction, u, itype))
+                        cmistake(u, ord, 36, MSG_EVENT);
+
+                    break;
                 }
             }
             /* try for a spell */

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1209,6 +1209,8 @@ static void test_show_without_item(CuTest *tc)
     item *i;
     struct locale *loc;
 
+    test_cleanup();
+
     loc = get_or_create_locale("de");
 
     r = test_create_region(0, 0, test_create_terrain("testregion", LAND_REGION));

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1235,6 +1235,7 @@ static void test_show_without_item(CuTest *tc)
     reshow_cmd(u, ord);
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") == NULL);
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error36") == NULL);
+    test_clear_messages(u->faction);
 
     free_order(ord);
     test_cleanup();

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1199,6 +1199,38 @@ static void test_mail_region_no_msg(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_show_without_item(CuTest *tc)
+{
+    unit *u;
+    order *ord;
+    item_type *itype;
+    item *i;
+
+    u = setup_name_cmd();
+    ord = create_order(K_RESHOW, u->faction->locale, "");
+    itype = it_get_or_create(rt_get_or_create("testitem"));
+    i = i_new(itype, 1);
+
+    reshow_cmd(u, ord);
+    CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") != NULL);
+    test_clear_messages(u->faction);
+
+    locale_setstring(get_locale("en"), "iteminfo::testitem", "testdescription");
+    reshow_cmd(u, ord);
+    CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") == NULL);
+    CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error36") != NULL);
+    test_clear_messages(u->faction);
+
+    i_add(&(u->items), i);
+    reshow_cmd(u, ord);
+    CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") == NULL);
+    CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error36") == NULL);
+
+    i_free(i);
+    free_order(ord);
+    test_cleanup();
+}
+
 CuSuite *get_laws_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -1255,6 +1287,7 @@ CuSuite *get_laws_suite(void)
     SUITE_ADD_TEST(suite, test_name_region);
     SUITE_ADD_TEST(suite, test_name_building);
     SUITE_ADD_TEST(suite, test_name_ship);
+    SUITE_ADD_TEST(suite, test_show_without_item);
 
     return suite;
 }

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1205,8 +1205,10 @@ static void test_show_without_item(CuTest *tc)
     order *ord;
     item_type *itype;
     item *i;
+    struct locale *loc;
 
     test_create_world();
+    loc = get_locale("de");
 
     u = test_create_unit(test_create_faction(test_create_race("human")), findregion(0, 0));
     ord = create_order(K_RESHOW, u->faction->locale, "testname");
@@ -1217,8 +1219,8 @@ static void test_show_without_item(CuTest *tc)
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") != NULL);
     test_clear_messages(u->faction);
 
-    locale_setstring(get_locale("de"), "testitem", "testname");
-    locale_setstring(get_locale("de"), "iteminfo::testitem", "testdescription");
+    locale_setstring(loc, "testitem", "testname");
+    locale_setstring(loc, "iteminfo::testitem", "testdescription");
     reshow_cmd(u, ord);
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") == NULL);
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error36") != NULL);

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1206,8 +1206,10 @@ static void test_show_without_item(CuTest *tc)
     item_type *itype;
     item *i;
 
-    u = setup_name_cmd();
-    ord = create_order(K_RESHOW, u->faction->locale, "");
+    test_create_world();
+
+    u = test_create_unit(test_create_faction(test_create_race("human")), findregion(0, 0));
+    ord = create_order(K_RESHOW, u->faction->locale, "testname");
     itype = it_get_or_create(rt_get_or_create("testitem"));
     i = i_new(itype, 1);
 
@@ -1215,7 +1217,8 @@ static void test_show_without_item(CuTest *tc)
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") != NULL);
     test_clear_messages(u->faction);
 
-    locale_setstring(get_locale("en"), "iteminfo::testitem", "testdescription");
+    locale_setstring(get_locale("de"), "testitem", "testname");
+    locale_setstring(get_locale("de"), "iteminfo::testitem", "testdescription");
     reshow_cmd(u, ord);
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") == NULL);
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error36") != NULL);
@@ -1226,7 +1229,6 @@ static void test_show_without_item(CuTest *tc)
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error21") == NULL);
     CuAssertTrue(tc, test_find_messagetype(u->faction->msgs, "error36") == NULL);
 
-    i_free(i);
     free_order(ord);
     test_cleanup();
 }

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1201,17 +1201,22 @@ static void test_mail_region_no_msg(CuTest *tc) {
 
 static void test_show_without_item(CuTest *tc)
 {
+    region *r;
+    faction *f;
     unit *u;
     order *ord;
     item_type *itype;
     item *i;
     struct locale *loc;
 
-    test_create_world();
-    loc = get_locale("de");
+    loc = get_or_create_locale("de");
 
-    u = test_create_unit(test_create_faction(test_create_race("human")), findregion(0, 0));
+    r = test_create_region(0, 0, test_create_terrain("testregion", LAND_REGION));
+    f = test_create_faction(test_create_race("human"));
+    u = test_create_unit(f, r);
+
     ord = create_order(K_RESHOW, u->faction->locale, "testname");
+
     itype = it_get_or_create(rt_get_or_create("testitem"));
     i = i_new(itype, 1);
 

--- a/src/spells/flyingship.c
+++ b/src/spells/flyingship.c
@@ -37,13 +37,20 @@ int sp_flying_ship(castorder * co)
 {
     ship *sh;
     unit *u;
-    region *r = co_get_region(co);
-    unit *mage = co->magician.u;
-    int cast_level = co->level;
-    double power = co->force;
-    spellparameter *pa = co->par;
+    region *r;
+    unit *mage;
+    int cast_level;
+    double power;
+    spellparameter *pa;
     message *m = NULL;
     int cno;
+
+    assert(co);
+    r = co_get_region(co);
+    mage = co->magician.u;
+    cast_level = co->level;
+    power = co->force;
+    pa = co->par;
 
     /* wenn kein Ziel gefunden, Zauber abbrechen */
     if (pa->param[0]->flag == TARGET_NOTFOUND)


### PR DESCRIPTION
Since the return of display_item() implies that the item, which is
definitely an item but not a potion at this point, is neither in the
inventory of the unit nor an item in the region or the faction's item
pool, the existing message 36 is now triggered in this case and the
previously conditional break is now done indepent of the outcome of
display_item, which shouldn't be critical (it's  an item so it can't be
a spell or a race).