### PR TITLE
fixed treatment of spell parameters (bug 1867)

### DIFF
--- a/res/e3a/spells.xml
+++ b/res/e3a/spells.xml
@@ -585,7 +585,7 @@
     <!-- Schutzzauber -->
     <resource name="aura" amount="5" cost="level"/>
   </spell>
-  <spell name="protective_runes" rank="2" index="99" parameters="kc" ship="true">
+  <spell name="protective_runes" rank="2" index="99" parameters="kc" regiontarget="false" unittarget="false" buildingtarget="true" shiptarget="true" ship="true">
     <resource name="aura" amount="20" cost="fixed"/>
   </spell>
   <spell name="analyze_magic" rank="5" index="102" parameters="kc?" los="true" ship="true" variable="true">

--- a/res/eressea/spells.xml
+++ b/res/eressea/spells.xml
@@ -313,7 +313,7 @@
   <spell name="keeploot" rank="5" index="98" variable="true" combat="3">
     <resource name="aura" amount="1" cost="level"/>
   </spell>
-  <spell name="protective_runes" rank="2" index="99" parameters="kc" ship="true">
+  <spell name="protective_runes" rank="2" index="99" parameters="kc" regiontarget="false" unittarget="false" buildingtarget="true" shiptarget="true" ship="true">
     <resource name="aura" amount="20" cost="fixed"/>
   </spell>
   <spell name="song_resist_magic" rank="2" index="100" far="true" variable="true">
@@ -332,7 +332,7 @@
     <resource name="aura" amount="10" cost="fixed"/>
   </spell>
   <spell name="analyse_object" rank="5" index="105" parameters="kc+" ship="true" variable="true">
-    <resource name="aura" amount="3" cost="level"/>
+    <resource name="aura" amount="3" cost="level" regiontarget="true" unittarget="false" buildingtarget="true" shiptarget="true"/>
   </spell>
   <spell name="destroy_magic" rank="2" index="106" parameters="kc+" los="true" ship="true" far="true" variable="true">
     <resource name="aura" amount="4" cost="level"/>

--- a/src/kernel/spell.test.c
+++ b/src/kernel/spell.test.c
@@ -8,7 +8,7 @@
 
 #include <stdlib.h>
 
-static void test_create_spell(CuTest * tc)
+static void test_create_a_spell(CuTest * tc)
 {
     spell * sp;
 
@@ -48,7 +48,7 @@ static void test_create_spell_with_id(CuTest * tc)
 CuSuite *get_spell_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
-    SUITE_ADD_TEST(suite, test_create_spell);
+    SUITE_ADD_TEST(suite, test_create_a_spell);
     SUITE_ADD_TEST(suite, test_create_duplicate_spell);
     SUITE_ADD_TEST(suite, test_create_spell_with_id);
     return suite;

--- a/src/kernel/xmlreader.c
+++ b/src/kernel/xmlreader.c
@@ -1484,6 +1484,16 @@ static int parse_spells(xmlDocPtr doc)
                 sp->sptyp |= FARCASTING;
             if (xml_bvalue(node, "variable", false))
                 sp->sptyp |= SPELLLEVEL;
+
+            if (xml_bvalue(node, "buildingtarget", false))
+                sp->sptyp |= BUILDINGSPELL;
+            if (xml_bvalue(node, "shiptarget", false))
+                sp->sptyp |= SHIPSPELL;
+            if (xml_bvalue(node, "unittarget", false))
+                sp->sptyp |= UNITSPELL;
+            if (xml_bvalue(node, "regiontarget", false))
+                sp->sptyp |= REGIONSPELL;
+
             k = xml_ivalue(node, "combat", 0);
             if (k >= 0 && k <= 3)
                 sp->sptyp |= modes[k];

--- a/src/magic.test.c
+++ b/src/magic.test.c
@@ -74,24 +74,6 @@ void test_spellbooks(CuTest * tc)
     test_cleanup();
 }
 
-static spell * test_magic_create_spell(void)
-{
-    spell *sp;
-    sp = create_spell("testspell", 0);
-
-    sp->components = (spell_component *)calloc(4, sizeof(spell_component));
-    sp->components[0].amount = 1;
-    sp->components[0].type = get_resourcetype(R_SILVER);
-    sp->components[0].cost = SPC_FIX;
-    sp->components[1].amount = 1;
-    sp->components[1].type = get_resourcetype(R_AURA);
-    sp->components[1].cost = SPC_LEVEL;
-    sp->components[2].amount = 1;
-    sp->components[2].type = get_resourcetype(R_HORSE);
-    sp->components[2].cost = SPC_LINEAR;
-    return sp;
-}
-
 void test_pay_spell(CuTest * tc)
 {
     spell *sp;
@@ -107,7 +89,7 @@ void test_pay_spell(CuTest * tc)
     u = test_create_unit(f, r);
     CuAssertPtrNotNull(tc, u);
 
-    sp = test_magic_create_spell();
+    sp = test_create_spell();
     CuAssertPtrNotNull(tc, sp);
 
     set_level(u, SK_MAGIC, 5);
@@ -141,7 +123,7 @@ void test_pay_spell_failure(CuTest * tc)
     u = test_create_unit(f, r);
     CuAssertPtrNotNull(tc, u);
 
-    sp = test_magic_create_spell();
+    sp = test_create_spell();
     CuAssertPtrNotNull(tc, sp);
 
     set_level(u, SK_MAGIC, 5);

--- a/src/report.c
+++ b/src/report.c
@@ -248,7 +248,7 @@ static size_t write_spell_modifier(spell * sp, int flag, const char * str, bool 
     return 0;
 }
 
-static void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
+void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
 {
     int bytes, k, itemanz, costtyp;
     char buf[4096];

--- a/src/report.c
+++ b/src/report.c
@@ -248,6 +248,8 @@ static size_t write_spell_modifier(spell * sp, int flag, const char * str, bool 
     return 0;
 }
 
+void nr_spell_syntax(struct stream *out, struct spellbook_entry * sbe, const struct locale *lang);
+
 void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
 {
     int bytes, k, itemanz, costtyp;
@@ -255,7 +257,6 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
     char *startp, *bufp = buf;
     size_t size = sizeof(buf) - 1;
     spell * sp = sbe->sp;
-    const char *params = sp->parameter;
 
     newline(out);
     centre(out, spell_name(sp, lang), true);
@@ -361,6 +362,20 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
     bufp = buf;
     size = sizeof(buf) - 1;
 
+    nr_spell_syntax(out, sbe, lang);
+
+    newline(out);
+}
+
+void nr_spell_syntax(stream *out, spellbook_entry * sbe, const struct locale *lang)
+{
+    int bytes;
+    char buf[4096];
+    char *bufp = buf;
+    size_t size = sizeof(buf) - 1;
+    spell * sp = sbe->sp;
+    const char *params = sp->parameter;
+
     if (sp->sptyp & ISCOMBATSPELL) {
         bytes = (int)strlcpy(bufp, LOC(lang, keyword(K_COMBATSPELL)), size);
     }
@@ -456,9 +471,14 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
                 WARN_STATIC_BUFFER();
         }
         else if (cp == 'k') {
-            if (*params == 'c') {
+            bool multi = false;
+            if (params && *params == 'c') {
                 /* skip over a potential id */
                 ++params;
+            }
+            if (params && *params == '+') {
+                ++params;
+                multi = true;
             }
             for (targetp = targets; targetp->flag; ++targetp) {
                 if (sp->sptyp & targetp->flag)
@@ -482,8 +502,7 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
                         bytes =
                             (int)_snprintf(bufp, size, " %s <%s>", parameters[targetp->param],
                                 locp);
-                        if (*params == '+') {
-                            ++params;
+                        if (multi) {
                             if (wrptr(&bufp, &size, bytes) != 0)
                                 WARN_STATIC_BUFFER();
                             bytes = (int)_snprintf(bufp, size, " [<%s> ...]", locp);
@@ -520,11 +539,13 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
             bytes = (int)_snprintf(bufp, size, " <%s>", locp);
             if (wrptr(&bufp, &size, bytes) != 0)
                 WARN_STATIC_BUFFER();
+        } else {
+           log_error("unknown spell parameter %c for spell", cp, sp->sname);
         }
     }
     *bufp = 0;
     paragraph(out, buf, 2, 0, 0);
-    newline(out);
+
 }
 
 static void

--- a/src/report.c
+++ b/src/report.c
@@ -305,7 +305,7 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
             if (sp->sptyp & SPELLLEVEL) {
                 bytes =
                     _snprintf(bufp, size, "  %d %s", itemanz, LOC(lang, resourcename(rtype,
-                    itemanz != 1)));
+                        itemanz != 1)));
                 if (wrptr(&bufp, &size, bytes) != 0)
                     WARN_STATIC_BUFFER();
                 if (costtyp == SPC_LEVEL || costtyp == SPC_LINEAR) {
@@ -464,24 +464,24 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
                 if (sp->sptyp & targetp->flag)
                     ++maxparam;
             }
-            if (maxparam > 1) {
+            if (!maxparam || maxparam > 1) {
                 bytes = (int)strlcpy(bufp, " (", size);
                 if (wrptr(&bufp, &size, bytes) != 0)
                     WARN_STATIC_BUFFER();
             }
             i = 0;
             for (targetp = targets; targetp->flag; ++targetp) {
-                if (sp->sptyp & targetp->flag) {
+                if (!maxparam || sp->sptyp & targetp->flag) {
                     if (i++ != 0) {
                         bytes = (int)strlcpy(bufp, " |", size);
                         if (wrptr(&bufp, &size, bytes) != 0)
                             WARN_STATIC_BUFFER();
                     }
-                    if (targetp->param) {
+                    if (targetp->param && targetp->vars) {
                         locp = LOC(lang, targetp->vars);
                         bytes =
                             (int)_snprintf(bufp, size, " %s <%s>", parameters[targetp->param],
-                            locp);
+                                locp);
                         if (*params == '+') {
                             ++params;
                             if (wrptr(&bufp, &size, bytes) != 0)
@@ -497,7 +497,7 @@ void nr_spell(stream *out, spellbook_entry * sbe, const struct locale *lang)
                         WARN_STATIC_BUFFER();
                 }
             }
-            if (maxparam > 1) {
+            if (!maxparam || maxparam > 1) {
                 bytes = (int)strlcpy(bufp, " )", size);
                 if (wrptr(&bufp, &size, bytes) != 0)
                     WARN_STATIC_BUFFER();

--- a/src/report.h
+++ b/src/report.h
@@ -20,12 +20,16 @@ extern "C" {
 #endif
 
     struct stream;
+    struct spellbook_entry;
     struct region;
     struct faction;
     void register_nr(void);
     void report_cleanup(void);
     void write_spaces(struct stream *out, size_t num);
     void write_travelthru(struct stream *out, const struct region * r, const struct faction * f);
+
+    void nr_spell(struct stream *out, struct spellbook_entry * sbe, const struct locale *lang);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/report.h
+++ b/src/report.h
@@ -28,6 +28,7 @@ extern "C" {
     void write_spaces(struct stream *out, size_t num);
     void write_travelthru(struct stream *out, const struct region * r, const struct faction * f);
 
+    void nr_spell_syntax(struct stream *out, struct spellbook_entry * sbe, const struct locale *lang);
     void nr_spell(struct stream *out, struct spellbook_entry * sbe, const struct locale *lang);
 
 #ifdef __cplusplus

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -347,10 +347,8 @@ static void test_spell_syntax(CuTest *tc, char *msg, spell_fixture *spell, char 
 }
 
 static void set_parameter(spell_fixture spell, char *value) {
-    if (spell.sp->parameter)
-        strcpy(spell.sp->parameter, value);
-    else
-        spell.sp->parameter = _strdup(value);
+    free(spell.sp->parameter);
+    spell.sp->parameter = _strdup(value);
 }
 
 static void test_write_spell_syntax(CuTest *tc) {
@@ -391,15 +389,19 @@ static void test_write_spell_syntax(CuTest *tc) {
     test_spell_syntax(tc, "r", &spell,   "  ZAUBERE \"Testzauber\" <x> <y>");
 
     set_parameter(spell, "bc");
+    free(spell.sp->syntax);
     spell.sp->syntax = _strdup("hodor");
     test_spell_syntax(tc, "bc hodor", &spell,   "  ZAUBERE \"Testzauber\" <bnr> <Hodor>");
     free(spell.sp->syntax);
+    spell.sp->syntax = 0;
 
-    /* no idea what ? is supposed to mean, optional parameter maybe?
-    set_parameter(spell, "kcc?");
-    spell.sp->syntax = _strdup("hodor");
-    test_spell_syntax(tc, "kcc?", &spell,   "  ZAUBERE \"Testzauber\" <bnr>");
+    /* There are no spells with optional parameters, so we don't force this, for now
+    set_parameter(spell, "c?");
     free(spell.sp->syntax);
+    spell.sp->syntax = _strdup("hodor");
+    test_spell_syntax(tc, "c?", &spell,   "  ZAUBERE \"Testzauber\" [<Hodor>]");
+    free(spell.sp->syntax);
+    spell.sp->syntax = 0;
     */
 
     set_parameter(spell, "kc+");

--- a/src/tests.c
+++ b/src/tests.c
@@ -190,6 +190,24 @@ void test_create_castorder(castorder *co, unit *u, int level, float force, int r
     free_order(ord);
 }
 
+spell * test_create_spell(void)
+{
+    spell *sp;
+    sp = create_spell("testspell", 0);
+
+    sp->components = (spell_component *)calloc(4, sizeof(spell_component));
+    sp->components[0].amount = 1;
+    sp->components[0].type = get_resourcetype(R_SILVER);
+    sp->components[0].cost = SPC_FIX;
+    sp->components[1].amount = 1;
+    sp->components[1].type = get_resourcetype(R_AURA);
+    sp->components[1].cost = SPC_LEVEL;
+    sp->components[2].amount = 1;
+    sp->components[2].type = get_resourcetype(R_HORSE);
+    sp->components[2].cost = SPC_LINEAR;
+    return sp;
+}
+
 void test_translate_param(const struct locale *lang, param_t param, const char *text) {
     struct critbit_tree **cb;
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -205,6 +205,8 @@ spell * test_create_spell(void)
     sp->components[2].amount = 1;
     sp->components[2].type = get_resourcetype(R_HORSE);
     sp->components[2].cost = SPC_LINEAR;
+    sp->syntax = 0;
+    sp->parameter = 0;
     return sp;
 }
 

--- a/src/tests.h
+++ b/src/tests.h
@@ -22,6 +22,7 @@ extern "C" {
     struct terrain_type;
     struct castorder;
     struct spellparameter;
+    struct spell;
 
     struct CuTest;
 
@@ -41,6 +42,7 @@ extern "C" {
     struct ship_type *test_create_shiptype(const char * name);
     struct building_type *test_create_buildingtype(const char *name);
     void test_create_castorder(struct castorder *co, struct unit *u, int level, float force, int range, struct spellparameter *par);
+    struct spell * test_create_spell(void);
 
     int RunAllTests(void);
     void test_translate_param(const struct locale *lang, param_t param, const char *text);


### PR DESCRIPTION
Dieser Patch behebt die falsche Anzeige der Zaubersyntax in Reporten, wie
'ZAUBERE "Magie analysieren" ( REGION | EINHEIT <enr> | SCHIFF <snr> | BURG <bnr> )'

Klappt alles sehr gut, ist getestet, nur leider kriege ich einen sehr merkwürdigen SEGFAULT, der nichts mit meinem Code zu tun haben scheint, weil er in einem Test passiert, den ich gar nicht angefasst habe. Ich bin ratlos. Kann mir jemand helfen?

test_eressea (1) [C/C++ Application]	
	/home/steffen/git/server-stm/build-x86_64-gcc-Debug/eressea/test_eressea [6687] [cores: 0]	
		Thread [1] 6687 [core: 0] (Suspended : Signal : SIGABRT:Aborted)	
			__GI_raise() at /build/buildd/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56 0x7ffff73dfcc9	
			__GI_abort() at /build/buildd/eglibc-2.19/stdlib/abort.c:89 0x7ffff73e30d8	
			__libc_message() at /build/buildd/eglibc-2.19/libio/../sysdeps/posix/libc_fatal.c:175 0x7ffff741c394	
			malloc_printerr() at /build/buildd/eglibc-2.19/malloc/malloc.c:4,996 0x7ffff74270f7	
			_int_malloc() at /build/buildd/eglibc-2.19/malloc/malloc.c:3,359 0x7ffff7429e04	
			__GI___libc_malloc() at /build/buildd/eglibc-2.19/malloc/malloc.c:2,891 0x7ffff742b7b0	
			add_message() at /home/steffen/git/server-stm/src/kernel/messages.c:307 0x4dd1c1	
			cmistake() at /home/steffen/git/server-stm/src/kernel/messages.c:279 0x4dd068	
			herbsearch() at /home/steffen/git/server-stm/src/alchemy.c:63 0x469e5e	
			test_herbsearch() at /home/steffen/git/server-stm/src/alchemy.test.c:45 0x41633c	
			<...more frames...>	
	gdb	



