### PR TITLE
Monster leftovers

### DIFF
--- a/res/e3a/races.xml
+++ b/res/e3a/races.xml
@@ -883,7 +883,7 @@
   </race>
 
   <race name="seaserpent" magres="0.500000" maxaura="1.0" regaura="1.0" weight="20000" capacity="5000" speed="1.0" hp="600" ac="3" damage="2d15" unarmedattack="0" unarmeddefense="0" attackmodifier="4" defensemodifier="4" scarepeasants="yes" swim="yes" teach="no" getitem="yes" resistbash="yes">
-    <ai splitsize="6" killpeasants="yes" moverandom="yes" learn="yes"/>
+    <ai splitsize="6" killpeasants="yes" moverandom="yes" learn="yes" moveattack="yes"/>
     <function name="name" value="namegeneric"/>
     <function name="move" value="moveswimming"/>
     <skill name="tactics" modifier="4"/>

--- a/res/eressea/races.xml
+++ b/res/eressea/races.xml
@@ -1171,7 +1171,7 @@
     <attack type="1" damage="1d1"/>
   </race>
   <race name="seaserpent" magres="0.500000" maxaura="1.000000" regaura="1.000000" recruitcost="5000" weight="20000" capacity="5000" speed="1.000000" hp="600" ac="3" damage="2d15" unarmedattack="0" unarmeddefense="0" attackmodifier="4" defensemodifier="4" scarepeasants="yes" swim="yes" teach="no" getitem="yes" resistbash="yes" unarmedguard="yes">
-    <ai splitsize="6" killpeasants="yes" moverandom="yes" learn="yes"/>
+    <ai splitsize="6" killpeasants="yes" moverandom="yes" learn="yes" moveattack="yes"/>
     <function name="name" value="namegeneric"/>
     <function name="move" value="moveswimming"/>
     <skill name="tactics" modifier="4"/>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ set(TESTS_SRC
   laws.test.c
   magic.test.c
   market.test.c
+  monsters.test.c
   move.test.c
   piracy.test.c
   prefix.test.c

--- a/src/kernel/race.h
+++ b/src/kernel/race.h
@@ -214,6 +214,7 @@ extern "C" {
 #define RCF_SHIPSPEED      (1<<26)      /* race gets +1 on shipspeed */
 #define RCF_STONEGOLEM     (1<<27)      /* race gets stonegolem properties */
 #define RCF_IRONGOLEM      (1<<28)      /* race gets irongolem properties */
+#define RCF_ATTACK_MOVED   (1<<29)      /* may attack if it has moved */
 
     /* Economic flags */
 #define ECF_KEEP_ITEM       (1<<1)   /* gibt Gegenstände weg */

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -55,6 +55,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <util/language.h>
 #include <util/lists.h>
 #include <util/log.h>
+#include <util/rand.h>
 #include <util/resolve.h>
 #include <util/rng.h>
 #include <util/variant.h>
@@ -1161,10 +1162,11 @@ void set_number(unit * u, int count)
     u->number = (unsigned short)count;
 }
 
-bool learn_skill(unit * u, skill_t sk, double chance)
+bool learn_skill(unit * u, skill_t sk, double learn_chance)
 {
     skill *sv = u->skills;
-    if (chance < 1.0 && rng_int() % 10000 >= chance * 10000)
+    if (learn_chance < 1.0 && rng_int() % 10000 >= learn_chance * 10000)
+    if (!chance(learn_chance))
         return false;
     while (sv != u->skills + u->skill_size) {
         assert(sv->weeks > 0);

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -27,6 +27,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "curse.h"
 #include "item.h"
 #include "move.h"
+#include "monster.h"
 #include "order.h"
 #include "plane.h"
 #include "race.h"
@@ -1945,7 +1946,7 @@ static double produceexp_chance(void) {
 
 void produceexp_ex(struct unit *u, skill_t sk, int n, bool (*learn)(unit *, skill_t, double))
 {
-    if (n != 0 && playerrace(u_race(u))) {
+    if (n != 0 && (is_monsters(u->faction) || playerrace(u_race(u)))) {
         double chance = produceexp_chance();
         if (chance > 0.0F) {
             learn(u, sk, (n * chance) / u->number);

--- a/src/kernel/xmlreader.c
+++ b/src/kernel/xmlreader.c
@@ -1604,6 +1604,8 @@ static void parse_ai(race * rc, xmlNodePtr node)
         rc->flags |= RCF_MOVERANDOM;
     if (xml_bvalue(node, "learn", false))
         rc->flags |= RCF_LEARN;
+    if (xml_bvalue(node, "moveattack", false))
+        rc->flags |= RCF_ATTACK_MOVED;
 }
 
 static int parse_races(xmlDocPtr doc)

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -655,7 +655,7 @@ static void test_unarmed_races_can_guard(CuTest *tc) {
 
     setup_guard(&fix, false);
     rc = rc_get_or_create(fix.u->_race->_name);
-    rc->flags |= RCF_UNARMEDGUARD;
+    fset(rc, RCF_UNARMEDGUARD);
     update_guards();
     CuAssertTrue(tc, fval(fix.u, UFL_GUARD));
     test_cleanup();

--- a/src/monster.c
+++ b/src/monster.c
@@ -69,7 +69,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 bool monster_is_waiting(const unit * u)
 {
-    if (fval(u, UFL_ISNEW | UFL_MOVED))
+    int test = fval(u_race(u), RCF_ATTACK_MOVED) ? UFL_ISNEW : UFL_ISNEW | UFL_MOVED;
+    if (fval(u, test))
         return true;
     return false;
 }

--- a/src/monsters.c
+++ b/src/monsters.c
@@ -766,8 +766,7 @@ void plan_monsters(faction * f)
 
     for (r = regions; r; r = r->next) {
         unit *u;
-        double rchance = attack_chance;
-        bool attacking = false;
+        bool attacking = chance(attack_chance);
 
         for (u = r->units; u; u = u->next) {
             attrib *ta;
@@ -785,11 +784,6 @@ void plan_monsters(faction * f)
                 produceexp(u, SK_PERCEPTION, u->number);
             }
 
-            if (rchance > 0.0) {
-                if (chance(rchance))
-                    attacking = true;
-                rchance = 0.0;
-            }
             if (u->status > ST_BEHIND) {
                 setstatus(u, ST_FIGHT);
                 /* all monsters fight */

--- a/src/monsters.c
+++ b/src/monsters.c
@@ -399,10 +399,10 @@ static int dragon_affinity_value(region * r, unit * u)
     int m = all_money(r, u->faction);
 
     if (u_race(u) == get_race(RC_FIREDRAGON)) {
-        return (int)(normalvariate(m, m / 2));
+        return dice(6, m / 6);
     }
     else {
-        return (int)(normalvariate(m, m / 4));
+        return dice(4, m / 8);
     }
 }
 
@@ -745,9 +745,10 @@ static order *plan_dragon(unit * u)
         }
     }
     if (long_order == NULL) {
+        int attempts = 0;
         skill_t sk = SK_PERCEPTION;
         /* study perception (or a random useful skill) */
-        while (!skill_enabled(sk) || u_race(u)->bonus[sk] < -5) {
+        while ((!skill_enabled(sk) || (attempts < MAXSKILLS && u_race(u)->bonus[sk] < (++attempts < 10?1:-5 )))) {
             sk = (skill_t)(rng_int() % MAXSKILLS);
         }
         long_order = create_order(K_STUDY, u->faction->locale, "'%s'",

--- a/src/monsters.c
+++ b/src/monsters.c
@@ -787,7 +787,7 @@ void plan_monsters(faction * f)
                 setstatus(u, ST_FIGHT);
                 /* all monsters fight */
             }
-            if (attacking && is_guard(u, GUARD_TAX)) {
+            if (attacking && (!r->land || is_guard(u, GUARD_TAX))) {
                 monster_attacks(u, true, false);
             }
 

--- a/src/monsters.c
+++ b/src/monsters.c
@@ -71,7 +71,7 @@
 #include <string.h>
 #include <assert.h>
 
-#define MOVECHANCE                  25  /* chance fuer bewegung */
+#define MOVECHANCE                  .25  /* chance fuer bewegung */
 #define DRAGON_RANGE 20         /* Max. Distanz zum nächsten Drachenziel */
 #define MAXILLUSION_TEXTS   3
 
@@ -83,6 +83,10 @@ static void give_peasants(unit *u, const item_type *itype, int reduce) {
 
 static double monster_attack_chance(void) {
     return get_param_flt(global.parameters, "rules.monsters.attack_chance", 0.4f);
+}
+
+static double random_move_chance(void) {
+    return get_param_flt(global.parameters, "rules.monsters.random_move_chance", MOVECHANCE);
 }
 
 static void reduce_weight(unit * u)
@@ -157,7 +161,7 @@ static order *monster_attack(unit * u, const unit * target)
     return create_order(K_ATTACK, u->faction->locale, "%i", target->no);
 }
 
-static int monster_attacks(unit * monster, bool respect_buildings, bool rich_only)
+int monster_attacks(unit * monster, bool respect_buildings, bool rich_only)
 {
     region *r = monster->region;
     unit *u2;
@@ -786,6 +790,7 @@ void plan_monsters(faction * f)
             if (attacking && is_guard(u, GUARD_TAX)) {
                 monster_attacks(u, true, false);
             }
+
             /* units with a plan to kill get ATTACK orders: */
             ta = a_find(u->attribs, &at_hate);
             if (ta && !monster_is_waiting(u)) {
@@ -818,7 +823,7 @@ void plan_monsters(faction * f)
                     }
                 }
                 else if (u_race(u)->flags & RCF_MOVERANDOM) {
-                    if (rng_int() % 100 < MOVECHANCE || check_overpopulated(u)) {
+                    if (chance(random_move_chance()) || check_overpopulated(u)) {
                         long_order = monster_move(r, u);
                     }
                 }

--- a/src/monsters.c
+++ b/src/monsters.c
@@ -412,10 +412,10 @@ static int dragon_affinity_value(region * r, unit * u)
     int m = all_money(r, u->faction);
 
     if (u_race(u) == get_race(RC_FIREDRAGON)) {
-        return dice(6, m / 6);
+        return dice(4, m / 2);
     }
     else {
-        return dice(4, m / 8);
+        return dice(6, m / 3);
     }
 }
 
@@ -779,7 +779,6 @@ void plan_monsters(faction * f)
             free_orders(&u->orders);
             if (skill_enabled(SK_PERCEPTION)) {
                 /* Monster bekommen jede Runde ein paar Tage Wahrnehmung dazu */
-                /* TODO: this only works for playerrace */
                 produceexp(u, SK_PERCEPTION, u->number);
             }
 

--- a/src/monsters.test.c
+++ b/src/monsters.test.c
@@ -145,6 +145,31 @@ static void test_monsters_waiting(CuTest * tc)
     test_cleanup();
 }
 
+static void test_seaserpent_attack(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+    race *rc;
+
+    create_monsters(&f, &f2, &r, &u, &m);
+    r = findregion(-1, 0);
+    u = test_create_unit(u->faction, r);
+    unit_setid(u, 2);
+    m = test_create_unit(m->faction, r);
+    u_setrace(m, rc = test_create_race("seaserpent"));
+    assert(!m->region->land);
+    fset(m, UFL_MOVED);
+    fset(rc, RCF_ATTACK_MOVED);
+
+    set_param(&global.parameters, "rules.monsters.attack_chance", "1");
+
+    plan_monsters(f2);
+
+    CuAssertPtrNotNull(tc, find_order("ATTACKIERE 2", m));
+    test_cleanup();
+}
+
 static void test_monsters_attack_not(CuTest * tc)
 {
     faction *f, *f2;
@@ -238,6 +263,7 @@ CuSuite *get_monsters_suite(void)
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_monsters_attack);
     SUITE_ADD_TEST(suite, test_monsters_attack_ocean);
+    SUITE_ADD_TEST(suite, test_seaserpent_attack);
     SUITE_ADD_TEST(suite, test_monsters_waiting);
     SUITE_ADD_TEST(suite, test_monsters_attack_not);
     SUITE_ADD_TEST(suite, test_dragon_attacks_the_rich);

--- a/src/monsters.test.c
+++ b/src/monsters.test.c
@@ -1,0 +1,247 @@
+#include <platform.h>
+#include <stdlib.h>
+
+#include <kernel/config.h>
+#include <kernel/faction.h>
+#include <kernel/item.h>
+#include <kernel/order.h>
+#include <kernel/race.h>
+#include <kernel/region.h>
+#include <kernel/terrain.h>
+#include <kernel/unit.h>
+
+#include "monster.h"
+#include "guard.h"
+#include "skill.h"
+
+#include <util/language.h>
+#include <util/language_struct.h>
+
+#include <CuTest.h>
+#include <tests.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+extern void plan_monsters(struct faction *f);
+extern int monster_attacks(unit * monster, bool respect_buildings, bool rich_only);
+
+static void init_language(void)
+{
+    locale* lang;
+    int i;
+
+    lang = get_or_create_locale("de");
+    locale_setstring(lang, "skill::unarmed", "Waffenloser Kampf");
+    locale_setstring(lang, "keyword::attack", "ATTACKIERE");
+    locale_setstring(lang, "keyword::study", "LERNE");
+    locale_setstring(lang, "keyword::tax", "TREIBE");
+    locale_setstring(lang, "keyword::loot", "PLUENDERE");
+    locale_setstring(lang, "keyword::guard", "BEWACHE");
+    locale_setstring(lang, "keyword::move", "NACH");
+    locale_setstring(lang, "keyword::message", "BOTSCHAFT");
+    locale_setstring(lang, "REGION", "REGION");
+    locale_setstring(lang, "east", "O");
+
+    for (i = 0; i < MAXKEYWORDS; ++i) {
+        if (!locale_getstring(lang, mkname("keyword", keywords[i])))
+            locale_setstring(lang, mkname("keyword", keywords[i]), keywords[i]);
+    }
+    for (i = 0; i < MAXSKILLS; ++i) {
+        if (!locale_getstring(lang, mkname("skill", skillnames[i])))
+            locale_setstring(lang, mkname("skill", skillnames[i]), skillnames[i]);
+    }
+    init_keywords(lang);
+    init_skills(lang);
+}
+
+static order *find_order(const char *expected, const unit *unit)
+{
+    char cmd[32];
+    order *order;
+    for (order = unit->orders; order; order = order->next) {
+        if (strcmp(expected, get_command(order, cmd, sizeof(cmd))) == 0) {
+            return order;
+        }
+    }
+    return NULL;
+}
+
+static void create_monsters(faction **player, faction **monsters, region **r, unit **u, unit **m) {
+    race* rc;
+
+    test_cleanup();
+
+    init_language();
+
+    test_create_world();
+    *player = test_create_faction(NULL);
+    *monsters = get_or_create_monsters();
+    assert(rc_find((*monsters)->race->_name));
+    rc = rc_get_or_create((*monsters)->race->_name);
+    fset(rc, RCF_UNARMEDGUARD);
+    fset(rc, RCF_NPC);
+    fset(*monsters, FFL_NOIDLEOUT);
+    assert(fval(*monsters, FFL_NPC) && fval((*monsters)->race, RCF_UNARMEDGUARD) && fval((*monsters)->race, RCF_NPC) && fval(*monsters, FFL_NOIDLEOUT));
+    (*monsters)->locale = default_locale;
+
+    *r = findregion(0, 0);
+
+    *u = test_create_unit(*player, *r);
+    unit_setid(*u, 1);
+    *m = test_create_unit(*monsters, *r);
+}
+
+static void test_monsters_attack(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+
+    create_monsters(&f, &f2, &r, &u, &m);
+
+    guard(m, GUARD_TAX);
+
+    set_param(&global.parameters, "rules.monsters.attack_chance", "1");
+
+    plan_monsters(f2);
+
+    CuAssertPtrNotNull(tc, find_order("ATTACKIERE 1", m));
+    test_cleanup();
+}
+
+static void test_monsters_attack_ocean(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+
+    create_monsters(&f, &f2, &r, &u, &m);
+    r = findregion(-1, 0);
+    u = test_create_unit(u->faction, r);
+    unit_setid(u, 2);
+    m = test_create_unit(m->faction, r);
+    assert(!m->region->land);
+
+    set_param(&global.parameters, "rules.monsters.attack_chance", "1");
+
+    plan_monsters(f2);
+
+    CuAssertPtrNotNull(tc, find_order("ATTACKIERE 2", m));
+    test_cleanup();
+}
+
+static void test_monsters_waiting(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+
+    create_monsters(&f, &f2, &r, &u, &m);
+    guard(m, GUARD_TAX);
+    fset(m, UFL_ISNEW);
+    monster_attacks(m, false, false);
+    CuAssertPtrEquals(tc, 0, find_order("ATTACKIERE 1", m));
+    test_cleanup();
+}
+
+static void test_monsters_attack_not(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+
+    create_monsters(&f, &f2, &r, &u, &m);
+
+    guard(m, GUARD_TAX);
+    guard(u, GUARD_TAX);
+
+    set_param(&global.parameters, "rules.monsters.attack_chance", "0");
+
+    plan_monsters(f2);
+
+    CuAssertPtrEquals(tc, 0, find_order("ATTACKIERE 1", m));
+    test_cleanup();
+}
+
+static void test_dragon_attacks_the_rich(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+    const item_type *i_silver;
+
+    init_language();
+    create_monsters(&f, &f2, &r, &u, &m);
+
+    guard(m, GUARD_TAX);
+    set_level(m, SK_WEAPONLESS, 10);
+
+    rsetmoney(r, 1);
+    rsetmoney(findregion(1, 0), 0);
+    i_silver = it_find("money");
+    assert(i_silver);
+    i_change(&u->items, i_silver, 5000);
+
+    set_param(&global.parameters, "rules.monsters.attack_chance", "0.00001");
+
+    plan_monsters(f2);
+
+    CuAssertPtrNotNull(tc, find_order("ATTACKIERE 1", m));
+    CuAssertPtrNotNull(tc, find_order("PLUENDERE", m));
+    test_cleanup();
+}
+
+static void test_dragon_moves(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+
+    create_monsters(&f, &f2, &r, &u, &m);
+    rsetpeasants(r, 0);
+    rsetmoney(r, 0);
+    rsetmoney(findregion(1, 0), 1000);
+
+    set_level(m, SK_WEAPONLESS, 10);
+    set_param(&global.parameters, "rules.monsters.attack_chance", ".0");
+    plan_monsters(f2);
+
+    CuAssertPtrNotNull(tc, find_order("NACH O", m));
+    test_cleanup();
+}
+
+static void test_monsters_learn_exp(CuTest * tc)
+{
+    faction *f, *f2;
+    region *r;
+    unit *u, *m;
+    skill* sk;
+
+    create_monsters(&f, &f2, &r, &u, &m);
+    set_param(&global.parameters, "study.from_use", "1");
+
+    u_setrace(u, u_race(m));
+    produceexp(u, SK_MELEE, u->number);
+    sk = unit_skill(u, SK_MELEE);
+    CuAssertTrue(tc, !sk);
+
+    produceexp(m, SK_MELEE, u->number);
+    sk = unit_skill(m, SK_MELEE);
+    CuAssertTrue(tc, sk && (sk->level > 0 || (sk->level == 0 && sk->weeks > 0)));
+
+    test_cleanup();
+}
+
+CuSuite *get_monsters_suite(void)
+{
+    CuSuite *suite = CuSuiteNew();
+    SUITE_ADD_TEST(suite, test_monsters_attack);
+    SUITE_ADD_TEST(suite, test_monsters_attack_ocean);
+    SUITE_ADD_TEST(suite, test_monsters_waiting);
+    SUITE_ADD_TEST(suite, test_monsters_attack_not);
+    SUITE_ADD_TEST(suite, test_dragon_attacks_the_rich);
+    SUITE_ADD_TEST(suite, test_dragon_moves);
+    SUITE_ADD_TEST(suite, test_monsters_learn_exp);
+    return suite;
+}

--- a/src/piracy.c
+++ b/src/piracy.c
@@ -9,6 +9,7 @@
 #include <kernel/faction.h>
 #include <kernel/messages.h>
 #include <kernel/order.h>
+#include <kernel/race.h>
 #include <kernel/region.h>
 #include <kernel/ship.h>
 #include <kernel/terrain.h>
@@ -64,6 +65,8 @@ static attrib *mk_piracy(const faction * pirate, const faction * target,
 }
 
 static bool validate_pirate(unit *u, order *ord) {
+    if (fval(u_race(u), RCF_SWIM | RCF_FLY))
+        return true;
     if (!u->ship) {
         cmistake(u, ord, 144, MSG_MOVE);
         return false;

--- a/src/test_eressea.c
+++ b/src/test_eressea.c
@@ -118,6 +118,7 @@ int RunAllTests(int argc, char *argv[])
     ADD_SUITE(give);
     ADD_SUITE(laws);
     ADD_SUITE(market);
+    ADD_SUITE(monsters);
     ADD_SUITE(move);
     ADD_SUITE(piracy);
     ADD_SUITE(stealth);

--- a/src/tests.c
+++ b/src/tests.c
@@ -238,10 +238,10 @@ void test_create_world(void)
     test_create_itemtype("iron");
     test_create_itemtype("stone");
 
-    t_plain = test_create_terrain("plain", LAND_REGION | FOREST_REGION | WALK_INTO | CAVALRY_REGION);
+    t_plain = test_create_terrain("plain", LAND_REGION | FOREST_REGION | WALK_INTO | CAVALRY_REGION | FLY_INTO);
     t_plain->size = 1000;
     t_plain->max_road = 100;
-    t_ocean = test_create_terrain("ocean", SEA_REGION | SAIL_INTO | SWIM_INTO);
+    t_ocean = test_create_terrain("ocean", SEA_REGION | SAIL_INTO | SWIM_INTO | FLY_INTO);
     t_ocean->size = 0;
 
     island[0] = test_create_region(0, 0, t_plain);


### PR DESCRIPTION
Ersetzt #177.
Das ist ein bisschen ein Sammelsurium und sollte nicht unbedingt ins release 3.7, aber es sind einige wichtige Verbesserungen (siehe einzelne Commits):
- kleine Codeverbesserungen und refactorings
- Monster können aus Erfahrung lernen
- Tests für monsters.c!
- Monster (incl. Seeschlangen!) können auf dem Ozean attackieren ohne zu bewachen
- Seeschlangen können Piraterie machen (sollten sie bisher, klappte aber nicht) und direkt nach der Bewegung attackieren.
