### PR TITLE
re-enable monster tests

### DIFF
--- a/src/monsters.c
+++ b/src/monsters.c
@@ -827,18 +827,6 @@ void plan_monsters(faction * f)
                 }
             }
 
-            if (long_order == NULL && unit_can_study(u)) {
-                /* Einheiten, die Waffenlosen Kampf lernen könnten, lernen es um
-                 * zu bewachen: */
-                if (u_race(u)->bonus[SK_WEAPONLESS] != -99) {
-                    if (effskill(u, SK_WEAPONLESS, 0) < 1) {
-                        long_order =
-                            create_order(K_STUDY, f->locale, "'%s'",
-                            skillname(SK_WEAPONLESS, f->locale));
-                    }
-                }
-            }
-
             if (long_order == NULL) {
                 /* Ab hier noch nicht generalisierte Spezialbehandlungen. */
 
@@ -867,6 +855,18 @@ void plan_monsters(faction * f)
                     break;
                 }
             }
+            if (long_order == NULL && unit_can_study(u)) {
+                /* Einheiten, die Waffenlosen Kampf lernen könnten, lernen es um
+                * zu bewachen: */
+                if (u_race(u)->bonus[SK_WEAPONLESS] != -99) {
+                    if (effskill(u, SK_WEAPONLESS, 0) < 1) {
+                        long_order =
+                            create_order(K_STUDY, f->locale, "'%s'",
+                                skillname(SK_WEAPONLESS, f->locale));
+                    }
+                }
+            }
+
             if (long_order) {
                 addlist(&u->orders, long_order);
             }

--- a/src/monsters.test.c
+++ b/src/monsters.test.c
@@ -264,10 +264,10 @@ CuSuite *get_monsters_suite(void)
     SUITE_ADD_TEST(suite, test_monsters_attack);
     SUITE_ADD_TEST(suite, test_monsters_attack_ocean);
     DISABLE_TEST(suite, test_seaserpent_piracy);
-    DISABLE_TEST(suite, test_monsters_waiting);
+    SUITE_ADD_TEST(suite, test_monsters_waiting);
     SUITE_ADD_TEST(suite, test_monsters_attack_not);
     SUITE_ADD_TEST(suite, test_dragon_attacks_the_rich);
-    DISABLE_TEST(suite, test_dragon_moves);
-    DISABLE_TEST(suite, test_monsters_learn_exp);
+    SUITE_ADD_TEST(suite, test_dragon_moves);
+    SUITE_ADD_TEST(suite, test_monsters_learn_exp);
     return suite;
 }

--- a/src/monsters.test.c
+++ b/src/monsters.test.c
@@ -263,7 +263,7 @@ CuSuite *get_monsters_suite(void)
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_monsters_attack);
     SUITE_ADD_TEST(suite, test_monsters_attack_ocean);
-    DISABLE_TEST(suite, test_seaserpent_piracy);
+    SUITE_ADD_TEST(suite, test_seaserpent_piracy);
     SUITE_ADD_TEST(suite, test_monsters_waiting);
     SUITE_ADD_TEST(suite, test_monsters_attack_not);
     SUITE_ADD_TEST(suite, test_dragon_attacks_the_rich);


### PR DESCRIPTION
This ends the stepwise merge of #404 except piracy for seaserpents, which is still not working, because they are currently learning unarmed combat as a long order instead.