### PR TITLE
break_curse spell description error message

### DIFF
--- a/res/e3a/spells.xml
+++ b/res/e3a/spells.xml
@@ -594,7 +594,7 @@
   <spell name="destroy_magic" rank="2" index="106" parameters="kc+" los="true" ship="true" far="true" variable="true">
     <resource name="aura" amount="4" cost="level"/>
   </spell>
-  <spell name="break_curse" rank="3" index="107" syntax="spellid" parameters="kcc?" los="true" ship="true" far="true" variable="true">
+  <spell name="break_curse" rank="3" index="107" syntax="spellid" parameters="kcc" los="true" ship="true" far="true" variable="true">
     <resource name="aura" amount="3" cost="level"/>
   </spell>
   <spell name="fish_shield" rank="2" index="109" variable="true" combat="1">

--- a/res/eressea/spells.xml
+++ b/res/eressea/spells.xml
@@ -337,7 +337,7 @@
   <spell name="destroy_magic" rank="2" index="106" parameters="kc+" los="true" ship="true" far="true" variable="true">
     <resource name="aura" amount="4" cost="level"/>
   </spell>
-  <spell name="break_curse" rank="3" index="107" syntax="spellid" parameters="kcc?" los="true" ship="true" far="true" variable="true">
+  <spell name="break_curse" rank="3" index="107" syntax="spellid" parameters="kcc" los="true" ship="true" far="true" variable="true">
     <resource name="aura" amount="3" cost="level"/>
   </spell>
   <spell name="meteor_rain" rank="5" index="108" variable="true" combat="2">

--- a/src/report.c
+++ b/src/report.c
@@ -536,11 +536,17 @@ void nr_spell_syntax(stream *out, spellbook_entry * sbe, const struct locale *la
                 locp = LOC(lang, mkname("spellpar", substr));
                 syntaxp = substr + 1;
             }
-            bytes = (int)_snprintf(bufp, size, " <%s>", locp);
+            if (*params == '?') {
+                ++params;
+                bytes = (int)_snprintf(bufp, size, " [<%s>]", locp);
+            }
+            else {
+                bytes = (int)_snprintf(bufp, size, " <%s>", locp);
+            }
             if (wrptr(&bufp, &size, bytes) != 0)
                 WARN_STATIC_BUFFER();
         } else {
-           log_error("unknown spell parameter %c for spell", cp, sp->sname);
+           log_error("unknown spell parameter %c for spell %s", cp, sp->sname);
         }
     }
     *bufp = 0;

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -393,14 +393,12 @@ static void test_write_spell_syntax(CuTest *tc) {
     free(spell.sp->syntax);
     spell.sp->syntax = 0;
 
-    /* There are no spells with optional parameters, so we don't force this, for now
     set_parameter(spell, "c?");
     free(spell.sp->syntax);
     spell.sp->syntax = _strdup("hodor");
     check_spell_syntax(tc, "c?", &spell,   "  ZAUBERE \"Testzauber\" [<Hodor>]");
     free(spell.sp->syntax);
     spell.sp->syntax = 0;
-    */
 
     set_parameter(spell, "kc+");
     check_spell_syntax(tc, "kc+", &spell,

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -313,22 +313,17 @@ static void setup_spell_fixture(spell_fixture * spf) {
     spf->sp = test_create_spell();
     spellbook_add(spf->spb, spf->sp, 1);
     spf->sbe = spellbook_get(spf->spb, spf->sp);
-
 }
 
-static void test_spell_syntax(CuTest *tc, char *msg, spell_fixture *spell, char *syntax) {
+static void check_spell_syntax(CuTest *tc, char *msg, spell_fixture *spell, char *syntax) {
     stream strm;
     char buf[1024];
     char *linestart, *newline;
     size_t len;
 
     mstream_init(&strm);
-
-
     nr_spell_syntax(&strm, spell->sbe, spell->lang);
-
     strm.api->rewind(strm.handle);
-
     len = strm.api->read(strm.handle, buf, sizeof(buf));
     buf[len] = '\0';
 
@@ -360,41 +355,41 @@ static void test_write_spell_syntax(CuTest *tc) {
     test_cleanup();
     setup_spell_fixture(&spell);
 
-    test_spell_syntax(tc, "vanilla",  &spell,   "  ZAUBERE \"Testzauber\"");
+    check_spell_syntax(tc, "vanilla",  &spell,   "  ZAUBERE \"Testzauber\"");
 
     spell.sp->sptyp |= FARCASTING;
-    test_spell_syntax(tc, "far",  &spell,   "  ZAUBERE [REGION x y] \"Testzauber\"");
+    check_spell_syntax(tc, "far",  &spell,   "  ZAUBERE [REGION x y] \"Testzauber\"");
 
     spell.sp->sptyp |= SPELLLEVEL;
-    test_spell_syntax(tc, "farlevel",  &spell,   "  ZAUBERE [REGION x y] [STUFE n] \"Testzauber\"");
+    check_spell_syntax(tc, "farlevel",  &spell,   "  ZAUBERE [REGION x y] [STUFE n] \"Testzauber\"");
     spell.sp->sptyp = 0;
 
     set_parameter(spell, "kc");
-    test_spell_syntax(tc, "kc", &spell,   "  ZAUBERE \"Testzauber\" ( REGION | EINHEIT <enr> | SCHIFF <snr> | BURG <bnr> )");
+    check_spell_syntax(tc, "kc", &spell,   "  ZAUBERE \"Testzauber\" ( REGION | EINHEIT <enr> | SCHIFF <snr> | BURG <bnr> )");
 
     spell.sp->sptyp |= BUILDINGSPELL;
-    test_spell_syntax(tc, "kc typed", &spell,   "  ZAUBERE \"Testzauber\" BURG <bnr>");
+    check_spell_syntax(tc, "kc typed", &spell,   "  ZAUBERE \"Testzauber\" BURG <bnr>");
     spell.sp->sptyp = 0;
 
     set_parameter(spell, "b");
-    test_spell_syntax(tc, "b", &spell,   "  ZAUBERE \"Testzauber\" <bnr>");
+    check_spell_syntax(tc, "b", &spell,   "  ZAUBERE \"Testzauber\" <bnr>");
 
     set_parameter(spell, "s");
-    test_spell_syntax(tc, "s", &spell,   "  ZAUBERE \"Testzauber\" <snr>");
+    check_spell_syntax(tc, "s", &spell,   "  ZAUBERE \"Testzauber\" <snr>");
 
     set_parameter(spell, "s+");
-    test_spell_syntax(tc, "s+", &spell,   "  ZAUBERE \"Testzauber\" <snr> [<snr> ...]");
+    check_spell_syntax(tc, "s+", &spell,   "  ZAUBERE \"Testzauber\" <snr> [<snr> ...]");
 
     set_parameter(spell, "u");
-    test_spell_syntax(tc, "u", &spell,   "  ZAUBERE \"Testzauber\" <enr>");
+    check_spell_syntax(tc, "u", &spell,   "  ZAUBERE \"Testzauber\" <enr>");
 
     set_parameter(spell, "r");
-    test_spell_syntax(tc, "r", &spell,   "  ZAUBERE \"Testzauber\" <x> <y>");
+    check_spell_syntax(tc, "r", &spell,   "  ZAUBERE \"Testzauber\" <x> <y>");
 
     set_parameter(spell, "bc");
     free(spell.sp->syntax);
     spell.sp->syntax = _strdup("hodor");
-    test_spell_syntax(tc, "bc hodor", &spell,   "  ZAUBERE \"Testzauber\" <bnr> <Hodor>");
+    check_spell_syntax(tc, "bc hodor", &spell,   "  ZAUBERE \"Testzauber\" <bnr> <Hodor>");
     free(spell.sp->syntax);
     spell.sp->syntax = 0;
 
@@ -402,13 +397,13 @@ static void test_write_spell_syntax(CuTest *tc) {
     set_parameter(spell, "c?");
     free(spell.sp->syntax);
     spell.sp->syntax = _strdup("hodor");
-    test_spell_syntax(tc, "c?", &spell,   "  ZAUBERE \"Testzauber\" [<Hodor>]");
+    check_spell_syntax(tc, "c?", &spell,   "  ZAUBERE \"Testzauber\" [<Hodor>]");
     free(spell.sp->syntax);
     spell.sp->syntax = 0;
     */
 
     set_parameter(spell, "kc+");
-    test_spell_syntax(tc, "kc+", &spell,
+    check_spell_syntax(tc, "kc+", &spell,
         "  ZAUBERE \"Testzauber\" ( REGION | EINHEIT <enr> [<enr> ...] | SCHIFF <snr>\n  [<snr> ...] | BURG <bnr> [<bnr> ...] )");
 
     test_cleanup();


### PR DESCRIPTION
stop the error message by fixing this spell's syntax.