### PR TITLE
magic resistance never higher than 90%

### DIFF
--- a/src/battle.test.c
+++ b/src/battle.test.c
@@ -330,8 +330,9 @@ static void test_magic_resistance(CuTest *tc)
     CuAssertDblEquals_Msg(tc, "race reduction", 0.4, magres, 0.01);
 
     rc->magres = 1.5; /* should not cause negative damage multiplier */
+    CuAssertDblEquals_Msg(tc, "magic resistance is never > 0.9", 0.9, magic_resistance(du), 0.01);
     calculate_armor(dt, 0, 0, &magres);
-    CuAssertDblEquals_Msg(tc, "damage reduction is never < 0", 0.0, magres, 0.01);
+    CuAssertDblEquals_Msg(tc, "damage reduction is never < 0.1", 0.1, magres, 0.01);
 
     free_battle(b);
     test_cleanup();

--- a/src/magic.c
+++ b/src/magic.c
@@ -1177,7 +1177,8 @@ double magic_resistance(unit * target)
         if (btype)
             probability += btype->magresbonus * 0.01;
     }
-    return probability;
+
+    return (probability<0.9) ? probability : 0.9;
 }
 
 /* ------------------------------------------------------------- */


### PR DESCRIPTION
https://bugs.eressea.de/view.php?id=2173#c6397 by request: magic resistance never higher than 90%, so highly skilled monsters cannot become completely invincible to magic.