### PR TITLE
smarter handling of faction.alive

### DIFF
--- a/src/bind_faction.c
+++ b/src/bind_faction.c
@@ -343,8 +343,14 @@ static int tolua_faction_get_origin(lua_State * L)
 
 static int tolua_faction_destroy(lua_State * L)
 {
-    faction *f = (faction *)tolua_tousertype(L, 1, 0);
-    destroyfaction(f);
+    faction **fp, *f = (faction *)tolua_tousertype(L, 1, 0);
+    // TODO: this loop is slow af, but what can we do?
+    for (fp = &factions; *fp; fp = &(*fp)->next) {
+        if (*fp == f) {
+            destroyfaction(fp);
+            break;
+        }
+    }
     return 0;
 }
 

--- a/src/kernel/alliance.c
+++ b/src/kernel/alliance.c
@@ -424,13 +424,14 @@ void alliancevictory(void)
     }
     while (al != NULL) {
         if (!fval(al, FFL_MARK)) {
-            int qi;
-            quicklist *flist = al->members;
-            for (qi = 0; flist; ql_advance(&flist, &qi, 1)) {
-                faction *f = (faction *)ql_get(flist, qi);
+            faction **fp;
+            for (fp = &factions; *fp; ) {
+                faction *f = *fp;
                 if (f->alliance == al) {
                     ADDMSG(&f->msgs, msg_message("alliance::lost", "alliance", al));
-                    destroyfaction(f);
+                    destroyfaction(fp);
+                } else {
+                    fp = &f->next;
                 }
             }
         }

--- a/src/kernel/faction.c
+++ b/src/kernel/faction.c
@@ -333,6 +333,7 @@ void destroyfaction(faction ** fp)
 
     *fp = f->next;
     fset(f, FFL_QUIT);
+    f->_alive = false;
 
     if (f->spellbook) {
         spellbook_clear(f->spellbook);
@@ -388,7 +389,6 @@ void destroyfaction(faction ** fp)
             u = u->nextF;
         }
     }
-    f->alive = false;
     /* no way!  f->units = NULL; */
     handle_event(f->attribs, "destroy", f);
     for (ff = factions; ff; ff = ff->next) {
@@ -648,7 +648,7 @@ void remove_empty_factions(void)
     for (fp = &factions; *fp;) {
         faction *f = *fp;
 
-        if ((!f->alive || !f->units) && !fval(f, FFL_NOIDLEOUT)) {
+        if (!(f->_alive && f->units!=NULL) && !fval(f, FFL_NOIDLEOUT)) {
             log_debug("dead: %s", factionname(f));
             destroyfaction(fp);
         }

--- a/src/kernel/faction.c
+++ b/src/kernel/faction.c
@@ -658,6 +658,11 @@ void remove_empty_factions(void)
     }
 }
 
+bool faction_alive(faction *f) {
+    assert(f);
+    return f->_alive || (f->flags&FFL_NPC);
+}
+
 void faction_getorigin(const faction * f, int id, int *x, int *y)
 {
     ursprung *ur;

--- a/src/kernel/faction.h
+++ b/src/kernel/faction.h
@@ -123,6 +123,8 @@ extern "C" {
     bool checkpasswd(const faction * f, const char *passwd);
     void destroyfaction(faction ** f);
 
+    bool faction_alive(struct faction *f);
+
     void set_alliance(struct faction *a, struct faction *b, int status);
     int get_alliance(const struct faction *a, const struct faction *b);
 

--- a/src/kernel/faction.h
+++ b/src/kernel/faction.h
@@ -103,7 +103,7 @@ extern "C" {
         struct item *items;         /* items this faction can claim */
         struct seen_region **seen;
         struct quicklist *seen_factions;
-        bool alive;              /* enno: sollte ein flag werden */
+        bool _alive;              /* enno: sollte ein flag werden */
     } faction;
 
     extern struct faction *factions;
@@ -121,7 +121,7 @@ extern "C" {
     struct faction *addfaction(const char *email, const char *password,
         const struct race *frace, const struct locale *loc, int subscription);
     bool checkpasswd(const faction * f, const char *passwd);
-    void destroyfaction(faction * f);
+    void destroyfaction(faction ** f);
 
     void set_alliance(struct faction *a, struct faction *b, int status);
     int get_alliance(const struct faction *a, const struct faction *b);

--- a/src/kernel/faction.test.c
+++ b/src/kernel/faction.test.c
@@ -107,7 +107,7 @@ static void test_addfaction(CuTest *tc) {
     CuAssertIntEquals(tc, 1234, f->subscription);
     CuAssertIntEquals(tc, 0, f->flags);
     CuAssertIntEquals(tc, 0, f->age);
-    CuAssertIntEquals(tc, true, f->_alive);
+    CuAssertIntEquals(tc, true, faction_alive(f));
     CuAssertIntEquals(tc, M_GRAY, f->magiegebiet);
     CuAssertIntEquals(tc, turn, f->lastorders);
     CuAssertPtrEquals(tc, f, findfaction(f->no));

--- a/src/kernel/faction.test.c
+++ b/src/kernel/faction.test.c
@@ -75,7 +75,7 @@ static void test_remove_dead_factions(CuTest *tc) {
     remove_empty_factions();
     CuAssertPtrEquals(tc, f, findfaction(f->no));
     CuAssertPtrNotNull(tc, get_monsters());
-    fm->alive = 0;
+    fm->units = 0;
     f->alive = 0;
     fno = f->no;
     remove_empty_factions();

--- a/src/kernel/faction.test.c
+++ b/src/kernel/faction.test.c
@@ -76,7 +76,7 @@ static void test_remove_dead_factions(CuTest *tc) {
     CuAssertPtrEquals(tc, f, findfaction(f->no));
     CuAssertPtrNotNull(tc, get_monsters());
     fm->units = 0;
-    f->alive = 0;
+    f->_alive = false;
     fno = f->no;
     remove_empty_factions();
     CuAssertPtrEquals(tc, 0, findfaction(fno));
@@ -107,7 +107,7 @@ static void test_addfaction(CuTest *tc) {
     CuAssertIntEquals(tc, 1234, f->subscription);
     CuAssertIntEquals(tc, 0, f->flags);
     CuAssertIntEquals(tc, 0, f->age);
-    CuAssertIntEquals(tc, 1, f->alive);
+    CuAssertIntEquals(tc, true, f->_alive);
     CuAssertIntEquals(tc, M_GRAY, f->magiegebiet);
     CuAssertIntEquals(tc, turn, f->lastorders);
     CuAssertPtrEquals(tc, f, findfaction(f->no));

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -1668,7 +1668,7 @@ int readgame(const char *filename, bool backup)
     log_debug("marking factions as alive.\n");
     for (f = factions; f; f = f->next) {
         if (f->flags & FFL_NPC) {
-            f->alive = 1;
+            f->_alive = true;
             f->magiegebiet = M_GRAY;
             if (f->no == 0) {
                 int no = 666;
@@ -1698,7 +1698,7 @@ int readgame(const char *filename, bool backup)
                     }
                 }
                 if (u->number > 0) {
-                    f->alive = true;
+                    f->_alive = true;
                     if (global.data_version >= SPELL_LEVEL_VERSION) {
                         break;
                     }

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1463,7 +1463,7 @@ unit *create_unit(region * r, faction * f, int number, const struct race *urace,
 
     assert(urace);
     if (f) {
-        assert(f->alive);
+        assert(f->_alive);
         u_setfaction(u, f);
 
         if (f->locale) {
@@ -1828,7 +1828,7 @@ void remove_empty_units_in_region(region * r)
 
         if (u->number) {
             faction *f = u->faction;
-            if (f == NULL || !f->alive) {
+            if (f == NULL || !f->_alive) {
                 set_number(u, 0);
             }
         }

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1463,7 +1463,7 @@ unit *create_unit(region * r, faction * f, int number, const struct race *urace,
 
     assert(urace);
     if (f) {
-        assert(f->_alive);
+        assert(faction_alive(f));
         u_setfaction(u, f);
 
         if (f->locale) {
@@ -1828,7 +1828,7 @@ void remove_empty_units_in_region(region * r)
 
         if (u->number) {
             faction *f = u->faction;
-            if (f == NULL || !f->_alive) {
+            if (f == NULL || !faction_alive(f)) {
                 set_number(u, 0);
             }
         }

--- a/src/kernel/unit.test.c
+++ b/src/kernel/unit.test.c
@@ -86,7 +86,7 @@ static void test_remove_units_with_dead_faction(CuTest *tc) {
 
     u = test_create_unit(test_create_faction(test_create_race("human")), findregion(0, 0));
     uid = u->no;
-    u->faction->alive = false;
+    u->faction->_alive = false;
     remove_empty_units_in_region(u->region);
     CuAssertPtrEquals(tc, 0, findunit(uid));
     CuAssertIntEquals(tc, 0, u->number);

--- a/src/laws.c
+++ b/src/laws.c
@@ -1244,7 +1244,7 @@ static void remove_idle_players(void)
     age = calloc(_max(4, turn + 1), sizeof(int));
     for (fp = &factions; *fp;) {
         faction *f = *fp;
-        if (f->alive && !is_monsters(f)) {
+        if (!is_monsters(f)) {
             if (RemoveNMRNewbie() && !fval(f, FFL_NOIDLEOUT)) {
                 if (f->age >= 0 && f->age <= turn)
                     ++age[f->age];
@@ -4267,18 +4267,16 @@ static int warn_password(void)
     faction *f;
     for (f = factions; f; f = f->next) {
         bool pwok = true;
-        if (f->alive) {
-            const char *c = f->passw;
-            while (*c && pwok) {
-                if (!isalnum((unsigned char)*c))
-                    pwok = false;
-                c++;
-            }
-            if (!pwok) {
-                free(f->passw);
-                f->passw = _strdup(itoa36(rng_int()));
-                ADDMSG(&f->msgs, msg_message("illegal_password", "newpass", f->passw));
-            }
+        const char *c = f->passw;
+        while (*c && pwok) {
+            if (!isalnum((unsigned char)*c))
+                pwok = false;
+            c++;
+        }
+        if (!pwok) {
+            free(f->passw);
+            f->passw = _strdup(itoa36(rng_int()));
+            ADDMSG(&f->msgs, msg_message("illegal_password", "newpass", f->passw));
         }
     }
     return 0;

--- a/src/summary.c
+++ b/src/summary.c
@@ -89,7 +89,7 @@ int update_nmrs(void)
         if (fval(f, FFL_ISNEW)) {
             ++newplayers;
         }
-        else if (!fval(f, FFL_NOIDLEOUT) && f->alive) {
+        else if (!fval(f, FFL_NOIDLEOUT)) {
             int nmr = turn - f->lastorders + 1;
             if (nmr < 0 || nmr > NMRTimeout()) {
                 log_error("faction %s has %d NMRS\n", factionid(f), nmr);
@@ -370,7 +370,7 @@ summary *make_summary(void)
         f->nregions = 0;
         f->num_total = 0;
         f->money = 0;
-        if (f->alive && f->units) {
+        if (f->units) {
             s->factions++;
             /* Problem mit Monsterpartei ... */
             if (!is_monsters(f)) {


### PR DESCRIPTION
Ich habe gerade den Code ein bisschen umgestellt, wegen eines crashes in Deveron am Sonntag morgen. Da war das Problem, dass free(f) gemacht wurde, statt destroyfaction(f).

Das ist eine doofe Sache. Wenn man die Partei löscht (mit free), dann muss man alle Referenzen auf sie entfernen. Es gibt aber einige Referenzen, für die das schwer ist. konkretes Beispiel hier: Regionsbesitzer. Statt jetzt alle Regionen abzufahren, und zu gucken ob die tote Partei dort Besitzer war, setzt destroyfaction() einfach nur f->alive auf false, und der Code für den Regionsbesitz muss dieses Flag checken. Wirklich gelöscht wird die Partei erst am Ende der Auswertung, nachdem das Datenfile geschrieben wurde.

Bisher musste man auch beim durchspulen der `factions` Liste aller Parteien checken, ob die Partei noch alive war. Das habe ich jetzt geändert, so dass destroyfaction einen Iterator in die Liste bekommt, und die Partei direkt entfernt. Das vermeidet hoffentlich eine Menge potenzielle Logik-Fehler. Um das zu verstärken, habe ich faction::alive in faction::_alive umbenannt, und dann alle Stellen an denen der Compiler über die fehlende Variable meckert, darauf untersucht, ob da die factions durchlaufen werden, oder der Zeiger auf die Partei aus einer anderen Quelle kam, und entsprechend den Code geändert.

Kleinen Nitpick habe ich noch: Member-Variablen, die mit Unterstrich beginnen, sollte der Code eigentlich nicht außerhalb des Moduls benutzen, zu dem die struct gehört (also hier nicht außerhalb von faction.c), aber in der Eile habe ich da geschludert und keine setter/getter geschrieben. Das liefere ich glaube ich noch nach, ehe ich den PR merge. 

This is a fix for issue #451 