### PR TITLE
Workaround and additional assertions for bug 2182

### DIFF
--- a/src/kernel/region.c
+++ b/src/kernel/region.c
@@ -605,9 +605,10 @@ int rpeasants(const region * r)
 
 void rsetpeasants(region * r, int value)
 {
-    assert(r->land);
     assert(value >= 0);
-    r->land->peasants = value;
+    if (r->land) {
+        r->land->peasants = value;
+    }
 }
 
 int rmoney(const region * r)
@@ -617,9 +618,11 @@ int rmoney(const region * r)
 
 void rsethorses(const region * r, int value)
 {
+    assert(r->land || value==0);
     assert(value >= 0);
-    if (r->land)
+    if (r->land) {
         r->land->horses = value;
+    }
 }
 
 int rhorses(const region * r)

--- a/src/kernel/region.c
+++ b/src/kernel/region.c
@@ -595,14 +595,19 @@ bool is_coastregion(region * r)
 
 int rpeasants(const region * r)
 {
-    return ((r)->land ? (r)->land->peasants : 0);
+    int value = 0;
+    if (r->land) {
+        value = r->land->peasants;
+        assert(value >= 0);
+    }
+    return value;
 }
 
 void rsetpeasants(region * r, int value)
 {
-    if (r->land) r->land->peasants = value;
-    else assert(value>=0);
-
+    assert(r->land);
+    assert(value >= 0);
+    r->land->peasants = value;
 }
 
 int rmoney(const region * r)

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -944,15 +944,19 @@ static region *readregion(struct gamedata *data, int x, int y)
         READ_INT(data->store, &n);
         rsetherbs(r, (short)n);
         READ_INT(data->store, &n);
-        rsetpeasants(r, n);
+        if (n < 0) {
+            /* bug 2182 */
+            log_error("data has negative peasants: %d in %s", n, regionname(r, 0));
+            rsetpeasants(r, 0);
+        }
+        else {
+            rsetpeasants(r, n);
+        }
         READ_INT(data->store, &n);
         rsetmoney(r, n);
     }
 
     assert(r->terrain != NULL);
-    assert(rhorses(r) >= 0);
-    assert(rpeasants(r) >= 0);
-    assert(rmoney(r) >= 0);
 
     if (r->land) {
         int n;


### PR DESCRIPTION
Workaround für Bug 2182, damit das Datenfile wieder gelesen werden kann.
https://bugs.eressea.de/view.php?id=2182

Zusätzliche Asserts, damit der Fehler in Zukunft früher gefunden wird, wenn er wieder auftritt.