### PR TITLE
disable password hashing in the 3.8 branch

### DIFF
--- a/scripts/tests/e3/rules.lua
+++ b/scripts/tests/e3/rules.lua
@@ -929,6 +929,7 @@ function test_volcanooutbreak_message()
     assert_not_equal("", msg:render("en"))
 end
 
+<<<<<<< HEAD
 function test_bug2083()
     local herb_multi = 500 -- from rc_herb_trade()
     local r = region.create(0,0,"plain")
@@ -961,7 +962,13 @@ function test_bug2083()
     assert_equal(0, u:get_item("balm"))
 end
 
+=======
+>>>>>>> release-3.7.11
 function test_no_uruk()
   local f1 = faction.create("noreply@eressea.de", "uruk", "de")
   assert_equal(f1.race, "orc")
 end
+<<<<<<< HEAD
+=======
+
+>>>>>>> release-3.7.11

--- a/scripts/tests/e3/rules.lua
+++ b/scripts/tests/e3/rules.lua
@@ -929,7 +929,6 @@ function test_volcanooutbreak_message()
     assert_not_equal("", msg:render("en"))
 end
 
-<<<<<<< HEAD
 function test_bug2083()
     local herb_multi = 500 -- from rc_herb_trade()
     local r = region.create(0,0,"plain")
@@ -962,13 +961,7 @@ function test_bug2083()
     assert_equal(0, u:get_item("balm"))
 end
 
-=======
->>>>>>> release-3.7.11
 function test_no_uruk()
   local f1 = faction.create("noreply@eressea.de", "uruk", "de")
   assert_equal(f1.race, "orc")
 end
-<<<<<<< HEAD
-=======
-
->>>>>>> release-3.7.11

--- a/share/debian-7_8.supp
+++ b/share/debian-7_8.supp
@@ -1,4 +1,14 @@
 {
+   strcpy.S:197
+   Memcheck:Cond
+   obj:/lib/x86_64-linux-gnu/libc-2.13.so
+}
+{
+   strcpy.S:1106
+   Memcheck:Value8
+   obj:/lib/x86_64-linux-gnu/libc-2.13.so
+}
+{
    stpncpy sse3
    Memcheck:Cond
    obj:/lib/x86_64-linux-gnu/libc-2.13.so

--- a/share/ubuntu-12_04.supp
+++ b/share/ubuntu-12_04.supp
@@ -1,12 +1,7 @@
 {
-   strcpy.S:197
-   Memcheck:Cond
-   obj:/lib/x86_64-linux-gnu/libc-2.13.so
-}
-{
-   strcpy.S:1106
+   stpncpy in strcpy-sse2-unaligned.S:1659
    Memcheck:Value8
-   obj:/lib/x86_64-linux-gnu/libc-2.13.so
+   __stpncpy_sse2_unaligned
 }
 # old zlib version
 {

--- a/share/ubuntu-12_04.supp
+++ b/share/ubuntu-12_04.supp
@@ -1,7 +1,7 @@
 {
    stpncpy in strcpy-sse2-unaligned.S:1659
    Memcheck:Value8
-   __stpncpy_sse2_unaligned
+   fun:__stpncpy_sse2_unaligned
 }
 # old zlib version
 {

--- a/share/ubuntu-12_04.supp
+++ b/share/ubuntu-12_04.supp
@@ -1,3 +1,13 @@
+{
+   strcpy.S:197
+   Memcheck:Cond
+   obj:/lib/x86_64-linux-gnu/libc-2.13.so
+}
+{
+   strcpy.S:1106
+   Memcheck:Value8
+   obj:/lib/x86_64-linux-gnu/libc-2.13.so
+}
 # old zlib version
 {
    zlib1g-dev-1:1.2.3.4.dfsg

--- a/src/bind_faction.c
+++ b/src/bind_faction.c
@@ -392,7 +392,7 @@ static int tolua_faction_set_password(lua_State * L)
 {
     faction *self = (faction *)tolua_tousertype(L, 1, 0);
     const char * passw = tolua_tostring(L, 2, 0);
-    faction_setpassword(self, password_hash(passw, 0, PASSWORD_DEFAULT));
+    faction_setpassword(self, password_encode(passw, PASSWORD_DEFAULT));
     return 0;
 }
 

--- a/src/buildno.h
+++ b/src/buildno.h
@@ -1,3 +1,3 @@
 #define VERSION_MAJOR 3
 #define VERSION_MINOR 8
-#define VERSION_BUILD 3
+#define VERSION_BUILD 4

--- a/src/kernel/faction.c
+++ b/src/kernel/faction.c
@@ -566,7 +566,8 @@ void faction_setbanner(faction * self, const char *banner)
 
 void faction_setpassword(faction * f, const char *pwhash)
 {
-    assert(pwhash && pwhash[0] == '$');
+    assert(pwhash);
+    // && pwhash[0] == '$');
     free(f->_password);
     f->_password = _strdup(pwhash);
 }

--- a/src/kernel/faction.c
+++ b/src/kernel/faction.c
@@ -252,7 +252,7 @@ faction *addfaction(const char *email, const char *password,
     }
 
     if (!password) password = itoa36(rng_int());
-    faction_setpassword(f, password_hash(password, 0, PASSWORD_DEFAULT));
+    faction_setpassword(f, password_encode(password, PASSWORD_DEFAULT));
     ADDMSG(&f->msgs, msg_message("changepasswd", "value", password));
 
     f->alliance_joindate = turn;

--- a/src/kernel/faction.test.c
+++ b/src/kernel/faction.test.c
@@ -108,12 +108,12 @@ static void test_addfaction(CuTest *tc) {
     CuAssertPtrEquals(tc, NULL, (void *)f->ursprung);
     CuAssertPtrEquals(tc, (void *)factions, (void *)f);
     CuAssertStrEquals(tc, "test@eressea.de", f->email);
-    CuAssertIntEquals(tc, true, checkpasswd(f, "hurrdurr"));
+    CuAssertTrue(tc, checkpasswd(f, "hurrdurr"));
     CuAssertPtrEquals(tc, (void *)lang, (void *)f->locale);
     CuAssertIntEquals(tc, 1234, f->subscription);
     CuAssertIntEquals(tc, 0, f->flags);
     CuAssertIntEquals(tc, 0, f->age);
-    CuAssertIntEquals(tc, true, faction_alive(f));
+    CuAssertTrue(tc, faction_alive(f));
     CuAssertIntEquals(tc, M_GRAY, f->magiegebiet);
     CuAssertIntEquals(tc, turn, f->lastorders);
     CuAssertPtrEquals(tc, f, findfaction(f->no));
@@ -125,9 +125,9 @@ static void test_check_passwd(CuTest *tc) {
     
     f = test_create_faction(0);
     faction_setpassword(f, password_hash("password", 0, PASSWORD_DEFAULT));
-    CuAssertIntEquals(tc, true, checkpasswd(f, "password"));
-    CuAssertIntEquals(tc, false, checkpasswd(f, "assword"));
-    CuAssertIntEquals(tc, false, checkpasswd(f, "PASSWORD"));
+    CuAssertTrue(tc, checkpasswd(f, "password"));
+    CuAssertTrue(tc, !checkpasswd(f, "assword"));
+    CuAssertTrue(tc, !checkpasswd(f, "PASSWORD"));
 }
 
 static void test_get_monsters(CuTest *tc) {

--- a/src/kernel/faction.test.c
+++ b/src/kernel/faction.test.c
@@ -124,7 +124,7 @@ static void test_check_passwd(CuTest *tc) {
     faction *f;
     
     f = test_create_faction(0);
-    faction_setpassword(f, password_hash("password", 0, PASSWORD_DEFAULT));
+    faction_setpassword(f, password_encode("password", PASSWORD_DEFAULT));
     CuAssertTrue(tc, checkpasswd(f, "password"));
     CuAssertTrue(tc, !checkpasswd(f, "assword"));
     CuAssertTrue(tc, !checkpasswd(f, "PASSWORD"));

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -1181,7 +1181,7 @@ static void read_password(gamedata *data, faction *f) {
     if (data->version == BADCRYPT_VERSION) {
         char * pass = getpasswd(f->no);
         if (pass) {
-            faction_setpassword(f, password_hash(pass, 0, PASSWORD_DEFAULT));
+            faction_setpassword(f, password_encode(pass, PASSWORD_DEFAULT));
             free(pass); // TODO: remove this allocation!
         }
         else {
@@ -1190,7 +1190,7 @@ static void read_password(gamedata *data, faction *f) {
         }
     }
     else {
-        faction_setpassword(f, (data->version >= CRYPT_VERSION) ? name : password_hash(name, 0, PASSWORD_DEFAULT));
+        faction_setpassword(f, (data->version >= CRYPT_VERSION) ? name : password_encode(name, PASSWORD_DEFAULT));
     }
 }
 

--- a/src/kernel/save.h
+++ b/src/kernel/save.h
@@ -83,6 +83,9 @@ extern "C" {
     struct gamedata *gamedata_open(const char *filename, const char *mode);
     void gamedata_close(struct gamedata *data);
 
+    /* test-only functions that give access to internal implementation details (BAD) */
+    void _test_write_password(struct gamedata *data, const struct faction *f);
+    void _test_read_password(struct gamedata *data, struct faction *f);
 #ifdef __cplusplus
 }
 #endif

--- a/src/kernel/save.test.c
+++ b/src/kernel/save.test.c
@@ -5,8 +5,13 @@
 #include "unit.h"
 #include "faction.h"
 #include "version.h"
+#include <util/base36.h>
+#include <util/password.h>
+
 #include <CuTest.h>
 #include <tests.h>
+
+#include <storage.h>
 
 #include <stdio.h>
 
@@ -42,15 +47,17 @@ static void test_readwrite_unit(CuTest * tc)
     u = test_create_unit(f, r);
     join_path(datapath(), filename, path, sizeof(path));
 
-    data = gamedata_open(path, "w");
-    CuAssertPtrNotNull(tc, data); // TODO: intermittent test
+    data = gamedata_open(path, "wb");
+    CuAssertPtrNotNull(tc, data);
+
     write_unit(data, u);
     gamedata_close(data);
 
     free_gamedata();
     f = test_create_faction(0);
     renumber_faction(f, fno);
-    data = gamedata_open(path, "r");
+    data = gamedata_open(path, "rb");
+    CuAssertPtrNotNull(tc, data);
     u = read_unit(data);
     gamedata_close(data);
 
@@ -61,10 +68,61 @@ static void test_readwrite_unit(CuTest * tc)
     test_cleanup();
 }
 
+static void test_read_password(CuTest *tc) {
+    const char *path = "test.dat";
+    gamedata *data;
+    faction *f;
+    f = test_create_faction(0);
+    faction_setpassword(f, password_hash("secret", 0, PASSWORD_DEFAULT));
+    data = gamedata_open(path, "wb");
+    CuAssertPtrNotNull(tc, data);
+    _test_write_password(data, f);
+    gamedata_close(data);
+    data = gamedata_open(path, "rb");
+    CuAssertPtrNotNull(tc, data);
+    _test_read_password(data, f);
+    gamedata_close(data);
+    CuAssertTrue(tc, checkpasswd(f, "secret"));
+    CuAssertIntEquals(tc, 0, remove(path));
+}
+
+static void test_read_password_external(CuTest *tc) {
+    const char *path = "test.dat", *pwfile = "passwords.txt";
+    gamedata *data;
+    faction *f;
+    FILE * F;
+
+    remove(pwfile);
+    f = test_create_faction(0);
+    faction_setpassword(f, password_hash("secret", 0, PASSWORD_DEFAULT));
+    CuAssertPtrNotNull(tc, f->_password);
+    data = gamedata_open(path, "wb");
+    CuAssertPtrNotNull(tc, data);
+    WRITE_TOK(data->store, (const char *)f->_password);
+    WRITE_TOK(data->store, (const char *)f->_password);
+    gamedata_close(data);
+    data = gamedata_open(path, "rb");
+    CuAssertPtrNotNull(tc, data);
+    data->version = BADCRYPT_VERSION;
+    _test_read_password(data, f);
+    CuAssertPtrEquals(tc, 0, f->_password);
+    F = fopen(pwfile, "wt");
+    fprintf(F, "%s:secret\n", itoa36(f->no));
+    fclose(F);
+    _test_read_password(data, f);
+    CuAssertPtrNotNull(tc, f->_password);
+    gamedata_close(data);
+    CuAssertTrue(tc, checkpasswd(f, "secret"));
+    CuAssertIntEquals(tc, 0, remove(path));
+    CuAssertIntEquals(tc, 0, remove(pwfile));
+}
+
 CuSuite *get_save_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_readwrite_data);
     SUITE_ADD_TEST(suite, test_readwrite_unit);
+    SUITE_ADD_TEST(suite, test_read_password);
+    SUITE_ADD_TEST(suite, test_read_password_external);
     return suite;
 }

--- a/src/kernel/save.test.c
+++ b/src/kernel/save.test.c
@@ -73,7 +73,7 @@ static void test_read_password(CuTest *tc) {
     gamedata *data;
     faction *f;
     f = test_create_faction(0);
-    faction_setpassword(f, password_hash("secret", 0, PASSWORD_DEFAULT));
+    faction_setpassword(f, password_encode("secret", PASSWORD_DEFAULT));
     data = gamedata_open(path, "wb");
     CuAssertPtrNotNull(tc, data);
     _test_write_password(data, f);
@@ -94,7 +94,7 @@ static void test_read_password_external(CuTest *tc) {
 
     remove(pwfile);
     f = test_create_faction(0);
-    faction_setpassword(f, password_hash("secret", 0, PASSWORD_DEFAULT));
+    faction_setpassword(f, password_encode("secret", PASSWORD_DEFAULT));
     CuAssertPtrNotNull(tc, f->_password);
     data = gamedata_open(path, "wb");
     CuAssertPtrNotNull(tc, data);

--- a/src/kernel/version.h
+++ b/src/kernel/version.h
@@ -33,9 +33,10 @@
 #define SPELL_LEVEL_VERSION 348 /* f->max_spelllevel gets stored, not calculated */
 #define OWNER_3_VERSION 349 /* regions store last owner, not last alliance */
 #define ATTRIBOWNER_VERSION 350 /* all attrib_type functions know who owns the attribute */
-#define CRYPT_VERSION 351 /* passwords are encrypted */
-#define RELEASE_VERSION CRYPT_VERSION /* current datafile */
+#define BADCRYPT_VERSION 351 /* passwords are encrypted, poorly */
+#define CRYPT_VERSION 352 /* passwords are encrypted */
+#define RELEASE_VERSION ATTRIBOWNER_VERSION /* current datafile */
 #define MIN_VERSION INTPAK_VERSION      /* minimal datafile we support */
-#define MAX_VERSION RELEASE_VERSION /* change this if we can need to read the future datafile, and we can do so */
+#define MAX_VERSION BADCRYPT_VERSION /* change this if we can need to read the future datafile, and we can do so */
 
 #define STREAM_VERSION 2 /* internal encoding of binary files */

--- a/src/laws.c
+++ b/src/laws.c
@@ -2172,7 +2172,7 @@ int password_cmd(unit * u, struct order *ord)
         cmistake(u, ord, 283, MSG_EVENT);
         strlcpy(pwbuf, itoa36(rng_int()), sizeof(pwbuf));
     }
-    faction_setpassword(u->faction, password_hash(pwbuf, 0, PASSWORD_DEFAULT));
+    faction_setpassword(u->faction, password_encode(pwbuf, PASSWORD_DEFAULT));
     ADDMSG(&u->faction->msgs, msg_message("changepasswd",
         "value", pwbuf));
     return 0;

--- a/src/util/gamedata.test.c
+++ b/src/util/gamedata.test.c
@@ -1,0 +1,25 @@
+#include <platform.h>
+#include "gamedata.h"
+
+#include <CuTest.h>
+#include <tests.h>
+#include <stdio.h>
+
+static void test_gamedata(CuTest * tc)
+{
+    gamedata *data;
+    data = gamedata_open("test.dat", "wb", 0);
+    CuAssertPtrNotNull(tc, data);
+    gamedata_close(data);
+    data = gamedata_open("test.dat", "rb", 0);
+    CuAssertPtrNotNull(tc, data);
+    gamedata_close(data);
+    CuAssertIntEquals(tc, 0, remove("test.dat"));
+}
+
+CuSuite *get_gamedata_suite(void)
+{
+    CuSuite *suite = CuSuiteNew();
+    SUITE_ADD_TEST(suite, test_gamedata);
+    return suite;
+}

--- a/src/util/password.c
+++ b/src/util/password.c
@@ -3,8 +3,8 @@
 
 #include <md5.h>
 #include <crypt_blowfish.h>
-#include <drepper.h>
 #include <mtrand.h>
+#include <drepper.h>
 
 #include <assert.h>
 #include <string.h>
@@ -79,7 +79,7 @@ static const char * password_hash_i(const char * passwd, const char *input, int 
                 salt_len = strlen(input);
             }
             assert(salt_len < MAXSALTLEN);
-            stpncpy(salt, input, salt_len);
+            memcpy(salt, input, salt_len);
             salt[salt_len] = 0;
         } else {
             input = password_gensalt(salt, sizeof(salt));

--- a/src/util/password.h
+++ b/src/util/password.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#define PASSWORD_PLAIN  '0'
+#define PASSWORD_PLAINTEXT 0
+#define PASSWORD_NOCRYPT '0'
 #define PASSWORD_MD5 '1'
 #define PASSWORD_BCRYPT '2' // not implemented
 #define PASSWORD_APACHE_MD5 'a'
 #define PASSWORD_SHA256 '5' // not implemented
 #define PASSWORD_SHA512 '6' // not implemented
-#define PASSWORD_DEFAULT PASSWORD_APACHE_MD5
+#define PASSWORD_DEFAULT PASSWORD_PLAINTEXT
 
 #define VERIFY_OK 0 // password matches hash
 #define VERIFY_FAIL 1 // password is wrong

--- a/src/util/password.h
+++ b/src/util/password.h
@@ -12,4 +12,4 @@
 #define VERIFY_FAIL 1 // password is wrong
 #define VERIFY_UNKNOWN 2 // hashing algorithm not supported
 int password_verify(const char *hash, const char *passwd);
-const char * password_hash(const char *passwd, const char *salt, int algo);
+const char * password_encode(const char *passwd, int algo);

--- a/src/util/password.test.c
+++ b/src/util/password.test.c
@@ -1,6 +1,7 @@
 #include <platform.h>
-#include <CuTest.h>
 #include "password.h"
+#include <CuTest.h>
+#include <string.h>
 
 static void test_passwords(CuTest *tc) {
     const char *hash, *expect;

--- a/src/util/password.test.c
+++ b/src/util/password.test.c
@@ -5,8 +5,6 @@
 static void test_passwords(CuTest *tc) {
     const char *hash, *expect;
 
-    CuAssertIntEquals(tc, VERIFY_UNKNOWN, password_verify("$9$password", "password"));
-
     expect = "$apr1$FqQLkl8g$.icQqaDJpim4BVy.Ho5660";
     CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "Hodor"));
     hash = password_encode("Hodor", PASSWORD_APACHE_MD5);
@@ -19,18 +17,27 @@ static void test_passwords(CuTest *tc) {
     CuAssertPtrNotNull(tc, hash);
     CuAssertIntEquals(tc, 0, strncmp(hash, expect, 3));
 
-    expect = "$0$password";
+    expect = "password";
+    hash = password_encode("password", PASSWORD_PLAINTEXT);
+    CuAssertPtrNotNull(tc, hash);
+    CuAssertStrEquals(tc, hash, expect);
     CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "password"));
     CuAssertIntEquals(tc, VERIFY_FAIL, password_verify(expect, "arseword"));
-    hash = password_encode("password", PASSWORD_PLAIN);
+
+    expect = "$0$password";
+    hash = password_encode("password", PASSWORD_NOCRYPT);
     CuAssertPtrNotNull(tc, hash);
-    CuAssertStrEquals(tc, expect, hash);
+    CuAssertStrEquals(tc, hash, expect);
+    CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "password"));
+    CuAssertIntEquals(tc, VERIFY_FAIL, password_verify(expect, "arseword"));
 
     expect = "$2y$05$RJ8qAhu.foXyJLdc2eHTLOaK4MDYn3/v4HtOVCq0Plv2yxcrEB7Wm";
     CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "Hodor"));
     hash = password_encode("Hodor", PASSWORD_BCRYPT);
     CuAssertPtrNotNull(tc, hash);
     CuAssertIntEquals(tc, 0, strncmp(hash, expect, 7));
+
+    CuAssertIntEquals(tc, VERIFY_UNKNOWN, password_verify("$9$saltyfish$password", "password"));
 }
 
 CuSuite *get_password_suite(void) {

--- a/src/util/password.test.c
+++ b/src/util/password.test.c
@@ -3,24 +3,31 @@
 #include "password.h"
 
 static void test_passwords(CuTest *tc) {
-    const char *hash;
+    const char *hash, *expect;
 
+    CuAssertIntEquals(tc, VERIFY_UNKNOWN, password_verify("$9$password", "password"));
+
+    expect = "$apr1$FqQLkl8g$.icQqaDJpim4BVy.Ho5660";
+    CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "Hodor"));
     hash = password_hash("Hodor", "FqQLkl8g", PASSWORD_APACHE_MD5);
     CuAssertPtrNotNull(tc, hash);
-    CuAssertStrEquals(tc, "$apr1$FqQLkl8g$.icQqaDJpim4BVy.Ho5660", hash);
-    CuAssertIntEquals(tc, VERIFY_OK, password_verify(hash, "Hodor"));
+    CuAssertStrEquals(tc, expect, hash);
 
+    expect = "$1$ZouUn04i$yNnT1Oy8azJ5V.UM9ppP5/";
+    CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "jollygood"));
     hash = password_hash("jollygood", "ZouUn04i", PASSWORD_MD5);
     CuAssertPtrNotNull(tc, hash);
-    CuAssertStrEquals(tc, "$1$ZouUn04i$yNnT1Oy8azJ5V.UM9ppP5/", hash);
-    CuAssertIntEquals(tc, VERIFY_OK, password_verify(hash, "jollygood"));
+    CuAssertStrEquals(tc, expect, hash);
 
+    expect = "$0$password";
+    CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "password"));
+    CuAssertIntEquals(tc, VERIFY_FAIL, password_verify(expect, "arseword"));
     hash = password_hash("password", "hodor", PASSWORD_PLAIN);
     CuAssertPtrNotNull(tc, hash);
-    CuAssertStrEquals(tc, "$0$hodor$password", hash);
-    CuAssertIntEquals(tc, VERIFY_OK, password_verify(hash, "password"));
-    CuAssertIntEquals(tc, VERIFY_FAIL, password_verify(hash, "arseword"));
-    CuAssertIntEquals(tc, VERIFY_UNKNOWN, password_verify("$9$saltyfish$password", "password"));
+    CuAssertStrEquals(tc, expect, hash);
+
+    expect = "$2y$05$RJ8qAhu.foXyJLdc2eHTLOaK4MDYn3/v4HtOVCq0Plv2yxcrEB7Wm";
+    CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "Hodor"));
 }
 
 CuSuite *get_password_suite(void) {

--- a/src/util/password.test.c
+++ b/src/util/password.test.c
@@ -9,25 +9,28 @@ static void test_passwords(CuTest *tc) {
 
     expect = "$apr1$FqQLkl8g$.icQqaDJpim4BVy.Ho5660";
     CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "Hodor"));
-    hash = password_hash("Hodor", "FqQLkl8g", PASSWORD_APACHE_MD5);
+    hash = password_encode("Hodor", PASSWORD_APACHE_MD5);
     CuAssertPtrNotNull(tc, hash);
-    CuAssertStrEquals(tc, expect, hash);
+    CuAssertIntEquals(tc, 0, strncmp(hash, expect, 6));
 
     expect = "$1$ZouUn04i$yNnT1Oy8azJ5V.UM9ppP5/";
     CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "jollygood"));
-    hash = password_hash("jollygood", "ZouUn04i", PASSWORD_MD5);
+    hash = password_encode("jollygood", PASSWORD_MD5);
     CuAssertPtrNotNull(tc, hash);
-    CuAssertStrEquals(tc, expect, hash);
+    CuAssertIntEquals(tc, 0, strncmp(hash, expect, 3));
 
     expect = "$0$password";
     CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "password"));
     CuAssertIntEquals(tc, VERIFY_FAIL, password_verify(expect, "arseword"));
-    hash = password_hash("password", "hodor", PASSWORD_PLAIN);
+    hash = password_encode("password", PASSWORD_PLAIN);
     CuAssertPtrNotNull(tc, hash);
     CuAssertStrEquals(tc, expect, hash);
 
     expect = "$2y$05$RJ8qAhu.foXyJLdc2eHTLOaK4MDYn3/v4HtOVCq0Plv2yxcrEB7Wm";
     CuAssertIntEquals(tc, VERIFY_OK, password_verify(expect, "Hodor"));
+    hash = password_encode("Hodor", PASSWORD_BCRYPT);
+    CuAssertPtrNotNull(tc, hash);
+    CuAssertIntEquals(tc, 0, strncmp(hash, expect, 7));
 }
 
 CuSuite *get_password_suite(void) {

--- a/tests/write-reports.sh
+++ b/tests/write-reports.sh
@@ -25,7 +25,7 @@ TESTS=../Debug/eressea/test_eressea
 SERVER=../Debug/eressea/eressea
 if [ -n "$VALGRIND" ]; then
 SUPP=../share/ubuntu-12_04.supp
-VALGRIND="$VALGRIND --suppressions=$SUPP --error-exitcode=1 --leak-check=no"
+VALGRIND="$VALGRIND --track-origins=yes --gen-suppressions=all --suppressions=$SUPP --error-exitcode=1 --leak-check=no"
 fi
 echo "running $TESTS"
 $VALGRIND $TESTS


### PR DESCRIPTION
It doesn't work, so I made a quickie hack that goes back to plain-text passwords.