### PR TITLE
Remove file operations from most tests

### DIFF
--- a/s/cmake-init
+++ b/s/cmake-init
@@ -16,6 +16,7 @@ MACHINE=`uname -m`
 [ -z "$CC" ] && [ ! -z `which cc` ] && CC="cc"
 BIN_DIR="$ROOT/build-$MACHINE-$CC-$BUILD"
 mkdir -p $BIN_DIR
+rm -f $BUILD
 ln -sf $BIN_DIR $BUILD
 
 MACHINE=$(gcc -dumpmachine)

--- a/src/eressea.c
+++ b/src/eressea.c
@@ -49,7 +49,7 @@ void game_done(void)
     calendar_cleanup();
 #endif
     free_functions();
-    free_curses();
+    curses_done();
     kernel_done();
 }
 

--- a/src/kernel/curse.c
+++ b/src/kernel/curse.c
@@ -57,7 +57,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <ctype.h>
 
 #define MAXENTITYHASH 7919
-curse *cursehash[MAXENTITYHASH];
+static curse *cursehash[MAXENTITYHASH];
 
 void c_setflag(curse * c, unsigned int flags)
 {

--- a/src/kernel/curse.c
+++ b/src/kernel/curse.c
@@ -74,17 +74,19 @@ void c_clearflag(curse * c, unsigned int flags)
 
 void chash(curse * c)
 {
-    curse *old = cursehash[c->no % MAXENTITYHASH];
+    int i = c->no % MAXENTITYHASH;
 
-    cursehash[c->no % MAXENTITYHASH] = c;
-    c->nexthash = old;
+    c->nexthash = cursehash[i];
+    cursehash[i] = c;
+    assert(c->nexthash != c);
 }
 
 static void cunhash(curse * c)
 {
     curse **show;
+    int i = c->no % MAXENTITYHASH;
 
-    for (show = &cursehash[c->no % MAXENTITYHASH]; *show;
+    for (show = &cursehash[i]; *show;
         show = &(*show)->nexthash) {
         if ((*show)->no == c->no)
             break;
@@ -195,6 +197,7 @@ int curse_read(attrib * a, void *owner, gamedata *data)
     int flags;
     float flt;
 
+    assert(!c->no);
     READ_INT(store, &c->no);
     chash(c);
     READ_TOK(store, cursename, sizeof(cursename));
@@ -824,7 +827,7 @@ double destr_curse(curse * c, int cast_level, double force)
     return force;
 }
 
-void free_curses(void) {
+void curses_done(void) {
     int i;
     for (i = 0; i != MAXCTHASH; ++i) {
         ql_free(cursetypes[i]);

--- a/src/kernel/curse.h
+++ b/src/kernel/curse.h
@@ -216,7 +216,7 @@ extern "C" {
         int duration;               /* Dauer der Verzauberung. Wird jede Runde vermindert */
     } curse;
 
-    void free_curses(void); /* de-register all curse-types */
+    void curses_done(void); /* de-register all curse-types */
 
     void curse_write(const struct attrib *a, const void *owner,
         struct storage *store);

--- a/src/kernel/group.test.c
+++ b/src/kernel/group.test.c
@@ -24,6 +24,8 @@
 #include <assert.h>
 
 static void test_group_readwrite_dead_faction(CuTest *tc) {
+    gamedata data;
+    storage store;
     faction *f, *f2;
     unit * u;
     group *g;
@@ -48,10 +50,15 @@ static void test_group_readwrite_dead_faction(CuTest *tc) {
     destroyfaction(&factions);
     CuAssertTrue(tc, !f->_alive);
     CuAssertPtrEquals(tc, f2, factions);
-    writegame("test.dat");
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
+    write_game(&data);
     free_gamedata();
     f = f2 = NULL;
-    readgame("test.dat", false);
+    data.strm.api->rewind(data.strm.handle);
+    read_game(&data);
+    mstream_done(&data.strm);
+    gamedata_done(&data);
     CuAssertPtrEquals(tc, 0, findfaction(fno));
     f2 = factions;
     CuAssertPtrNotNull(tc, f2);

--- a/src/kernel/group.test.c
+++ b/src/kernel/group.test.c
@@ -1,4 +1,5 @@
 #include <platform.h>
+#include "config.h"
 #include "types.h"
 #include "ally.h"
 #include "group.h"
@@ -15,11 +16,52 @@
 #include <stream.h>
 #include <filestream.h>
 #include <storage.h>
+#include <memstream.h>
 #include <binarystore.h>
 
 #include <CuTest.h>
 #include <tests.h>
 #include <assert.h>
+
+static void test_group_readwrite_dead_faction(CuTest *tc) {
+    faction *f, *f2;
+    unit * u;
+    group *g;
+    ally *al;
+    int fno;
+
+    test_cleanup();
+    f = test_create_faction(0);
+    fno = f->no;
+    CuAssertPtrEquals(tc, f, factions);
+    CuAssertPtrEquals(tc, 0, f->next);
+    f2 = test_create_faction(0);
+    CuAssertPtrEquals(tc, f2, factions->next);
+    u = test_create_unit(f2, test_create_region(0, 0, 0));
+    CuAssertPtrNotNull(tc, u);
+    g = join_group(u, "group");
+    CuAssertPtrNotNull(tc, g);
+    al = ally_add(&g->allies, f);
+    CuAssertPtrNotNull(tc, al);
+
+    CuAssertPtrEquals(tc, f, factions);
+    destroyfaction(&factions);
+    CuAssertTrue(tc, !f->_alive);
+    CuAssertPtrEquals(tc, f2, factions);
+    writegame("test.dat");
+    free_gamedata();
+    f = f2 = NULL;
+    readgame("test.dat", false);
+    CuAssertPtrEquals(tc, 0, findfaction(fno));
+    f2 = factions;
+    CuAssertPtrNotNull(tc, f2);
+    u = f2->units;
+    CuAssertPtrNotNull(tc, u);
+    g = get_group(u);
+    CuAssertPtrNotNull(tc, g);
+    CuAssertPtrEquals(tc, 0, g->allies);
+    test_cleanup();
+}
 
 static void test_group_readwrite(CuTest * tc)
 {
@@ -27,28 +69,28 @@ static void test_group_readwrite(CuTest * tc)
     group *g;
     ally *al;
     int i;
-    gamedata *data;
+    gamedata data;
+    storage store;
 
     test_cleanup();
-    data = gamedata_open("test.dat", "wb", RELEASE_VERSION);
-    CuAssertPtrNotNull(tc, data);
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
     f = test_create_faction(0);
     g = new_group(f, "NW", 42);
     g = new_group(f, "Egoisten", 43);
     key_set(&g->attribs, 44);
     al = ally_add(&g->allies, f);
     al->status = HELP_GIVE;
-    write_groups(data->store, f);
-    WRITE_INT(data->store, 47);
-    binstore_done(data->store);
-    gamedata_close(data);
+    write_groups(&store, f);
+    WRITE_INT(&store, 47);
 
-    f->groups = 0;
     free_group(g);
-    data = gamedata_open("test.dat", "rb", RELEASE_VERSION);
-    read_groups(data, f);
-    READ_INT(data->store, &i);
-    gamedata_close(data);
+    f->groups = 0;
+    data.strm.api->rewind(data.strm.handle);
+    read_groups(&data, f);
+    READ_INT(&store, &i);
+    mstream_done(&data.strm);
+    gamedata_done(&data);
 
     CuAssertIntEquals(tc, 47, i);
     CuAssertPtrNotNull(tc, f->groups);
@@ -64,7 +106,6 @@ static void test_group_readwrite(CuTest * tc)
     CuAssertPtrEquals(tc, 0, g->allies->next);
     CuAssertPtrEquals(tc, f, g->allies->faction);
     CuAssertIntEquals(tc, HELP_GIVE, g->allies->status);
-    remove("test.dat");
     test_cleanup();
 }
 
@@ -76,8 +117,7 @@ static void test_group(CuTest * tc)
     group *g;
 
     test_cleanup();
-    test_create_world();
-    r = findregion(0, 0);
+    r = test_create_region(0, 0, 0);
     f = test_create_faction(0);
     assert(r && f);
     u = test_create_unit(f, r);
@@ -100,6 +140,7 @@ CuSuite *get_group_suite(void)
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_group);
     SUITE_ADD_TEST(suite, test_group_readwrite);
+    SUITE_ADD_TEST(suite, test_group_readwrite_dead_faction);
     return suite;
 }
 

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -1540,8 +1540,8 @@ int read_game(gamedata *data) {
     global.data_turn = turn;
     log_debug(" - reading turn %d\n", turn);
     rng_init(turn);
-    READ_INT(store, &nread);          /* max_unique_id = ignore */
-    READ_INT(store, &nextborder);
+    READ_INT(store, NULL);          /* max_unique_id = ignore */
+    READ_INT(store, NULL);
 
     /* Planes */
     planes = NULL;
@@ -1619,7 +1619,7 @@ int read_game(gamedata *data) {
     /* Regionen */
 
     READ_INT(store, &nread);
-    assert(nread < MAXREGIONS);
+    assert(nread < MAXREGIONS && nread>=0);
     if (rmax < 0) {
         rmax = nread;
     }
@@ -1883,8 +1883,8 @@ int write_game(gamedata *data) {
     WRITE_SECTION(store);
 
     WRITE_INT(store, turn);
-    WRITE_INT(store, 0 /*max_unique_id */);
-    WRITE_INT(store, nextborder);
+    WRITE_INT(store, 0 /* max_unique_id */);
+    WRITE_INT(store, 0 /* nextborder */);
 
     /* Write planes */
     WRITE_SECTION(store);

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -1842,6 +1842,7 @@ int writegame(const char *filename)
     fstream_init(&strm, F);
     binstore_init(&store, &strm);
 
+    WRITE_INT(&store, VERSION_BUILD);
     n = write_game(&gdata);
     binstore_done(&store);
     fstream_done(&strm);
@@ -1875,7 +1876,6 @@ int write_game(gamedata *data) {
     /* globale Variablen */
     assert(data->version <= MAX_VERSION && data->version >= MIN_VERSION);
 
-    WRITE_INT(store, VERSION_BUILD);
     WRITE_INT(store, game_id());
     WRITE_SECTION(store);
 

--- a/src/kernel/save.h
+++ b/src/kernel/save.h
@@ -78,6 +78,9 @@ extern "C" {
 
     void create_backup(char *file);
 
+    int write_game(gamedata *data);
+    int read_game(gamedata *data);
+
     /* test-only functions that give access to internal implementation details (BAD) */
     void _test_write_password(struct gamedata *data, const struct faction *f);
     void _test_read_password(struct gamedata *data, struct faction *f);

--- a/src/kernel/save.test.c
+++ b/src/kernel/save.test.c
@@ -182,6 +182,8 @@ static void test_readwrite_dead_faction_regionowner(CuTest *tc) {
 }
 
 static void test_readwrite_dead_faction_changefaction(CuTest *tc) {
+    gamedata data;
+    storage store;
     faction *f, *f2;
     region *r;
     trigger *tr;
@@ -197,10 +199,15 @@ static void test_readwrite_dead_faction_changefaction(CuTest *tc) {
     destroyfaction(&factions);
     CuAssertTrue(tc, !f->_alive);
     remove_empty_units();
-    writegame("test.dat");
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
+    write_game(&data);
     free_gamedata();
     f = NULL;
-    readgame("test.dat", false);
+    data.strm.api->rewind(data.strm.handle);
+    read_game(&data);
+    mstream_done(&data.strm);
+    gamedata_done(&data);
     f = factions;
     CuAssertPtrNotNull(tc, f);
     r = regions;
@@ -212,6 +219,8 @@ static void test_readwrite_dead_faction_changefaction(CuTest *tc) {
 }
 
 static void test_readwrite_dead_faction_createunit(CuTest *tc) {
+    gamedata data;
+    storage store;
     faction *f, *f2;
     region *r;
     trigger *tr;
@@ -227,10 +236,15 @@ static void test_readwrite_dead_faction_createunit(CuTest *tc) {
     destroyfaction(&factions);
     CuAssertTrue(tc, !f->_alive);
     remove_empty_units();
-    writegame("test.dat");
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
+    write_game(&data);
     free_gamedata();
     f = NULL;
-    readgame("test.dat", false);
+    data.strm.api->rewind(data.strm.handle);
+    read_game(&data);
+    mstream_done(&data.strm);
+    gamedata_done(&data);
     f = factions;
     CuAssertPtrNotNull(tc, f);
     r = regions;
@@ -242,26 +256,26 @@ static void test_readwrite_dead_faction_createunit(CuTest *tc) {
 }
 
 static void test_read_password(CuTest *tc) {
-    const char *path = "test.dat";
-    gamedata *data;
+    gamedata data;
+    storage store;
     faction *f;
+
     f = test_create_faction(0);
     faction_setpassword(f, password_encode("secret", PASSWORD_DEFAULT));
-    data = gamedata_open(path, "wb", RELEASE_VERSION);
-    CuAssertPtrNotNull(tc, data);
-    _test_write_password(data, f);
-    gamedata_close(data);
-    data = gamedata_open(path, "rb", RELEASE_VERSION);
-    CuAssertPtrNotNull(tc, data);
-    _test_read_password(data, f);
-    gamedata_close(data);
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
+    _test_write_password(&data, f);
+    data.strm.api->rewind(data.strm.handle);
+    _test_read_password(&data, f);
+    mstream_done(&data.strm);
+    gamedata_done(&data);
     CuAssertTrue(tc, checkpasswd(f, "secret"));
-    CuAssertIntEquals(tc, 0, remove(path));
 }
 
 static void test_read_password_external(CuTest *tc) {
-    const char *path = "test.dat", *pwfile = "passwords.txt";
-    gamedata *data;
+    gamedata data;
+    storage store;
+    const char *pwfile = "passwords.txt";
     faction *f;
     FILE * F;
 
@@ -269,24 +283,21 @@ static void test_read_password_external(CuTest *tc) {
     f = test_create_faction(0);
     faction_setpassword(f, password_encode("secret", PASSWORD_DEFAULT));
     CuAssertPtrNotNull(tc, f->_password);
-    data = gamedata_open(path, "wb", RELEASE_VERSION);
-    CuAssertPtrNotNull(tc, data);
-    WRITE_TOK(data->store, (const char *)f->_password);
-    WRITE_TOK(data->store, (const char *)f->_password);
-    gamedata_close(data);
-    data = gamedata_open(path, "rb", RELEASE_VERSION);
-    CuAssertPtrNotNull(tc, data);
-    data->version = BADCRYPT_VERSION;
-    _test_read_password(data, f);
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
+    WRITE_TOK(data.store, (const char *)f->_password);
+    WRITE_TOK(data.store, (const char *)f->_password);
+    data.strm.api->rewind(data.strm.handle);
+    data.version = BADCRYPT_VERSION;
+    _test_read_password(&data, f);
     CuAssertPtrEquals(tc, 0, f->_password);
     F = fopen(pwfile, "wt");
     fprintf(F, "%s:secret\n", itoa36(f->no));
     fclose(F);
-    _test_read_password(data, f);
+    _test_read_password(&data, f);
     CuAssertPtrNotNull(tc, f->_password);
-    gamedata_close(data);
+    gamedata_done(&data);
     CuAssertTrue(tc, checkpasswd(f, "secret"));
-    CuAssertIntEquals(tc, 0, remove(path));
     CuAssertIntEquals(tc, 0, remove(pwfile));
 }
 

--- a/src/kernel/save.test.c
+++ b/src/kernel/save.test.c
@@ -152,6 +152,11 @@ static void test_readwrite_dead_faction_group(CuTest *tc) {
 static void test_readwrite_dead_faction_regionowner(CuTest *tc) {
     faction *f;
     region *r;
+    gamedata data;
+    storage store;
+
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
 
     test_cleanup();
     config_set("rules.region_owners", "1");
@@ -161,10 +166,13 @@ static void test_readwrite_dead_faction_regionowner(CuTest *tc) {
     destroyfaction(&factions);
     CuAssertTrue(tc, !f->_alive);
     remove_empty_units();
-    writegame("test.dat");
+    write_game(&data);
     free_gamedata();
     f = NULL;
-    readgame("test.dat", false);
+    data.strm.api->rewind(data.strm.handle);
+    read_game(&data);
+    mstream_done(&data.strm);
+    gamedata_done(&data);
     f = factions;
     CuAssertPtrEquals(tc, 0, f);
     r = regions;

--- a/src/kernel/save.test.c
+++ b/src/kernel/save.test.c
@@ -107,6 +107,11 @@ static void test_readwrite_dead_faction_group(CuTest *tc) {
     group *g;
     ally *al;
     int fno;
+    gamedata data;
+    storage store;
+
+    mstream_init(&data.strm);
+    gamedata_init(&data, &store, RELEASE_VERSION);
 
     test_cleanup();
     f = test_create_faction(0);
@@ -126,10 +131,11 @@ static void test_readwrite_dead_faction_group(CuTest *tc) {
     destroyfaction(&factions);
     CuAssertTrue(tc, !f->_alive);
     CuAssertPtrEquals(tc, f2, factions);
-    writegame("test.dat");
+    write_game(&data);
     free_gamedata();
     f = f2 = NULL;
-    readgame("test.dat", false);
+    data.strm.api->rewind(data.strm.handle);
+    read_game(&data);
     CuAssertPtrEquals(tc, 0, findfaction(fno));
     f2 = factions;
     CuAssertPtrNotNull(tc, f2);
@@ -138,6 +144,8 @@ static void test_readwrite_dead_faction_group(CuTest *tc) {
     g = get_group(u);
     CuAssertPtrNotNull(tc, g);
     CuAssertPtrEquals(tc, 0, g->allies);
+    mstream_done(&data.strm);
+    gamedata_done(&data);
     test_cleanup();
 }
 


### PR DESCRIPTION
On my Windows machine, several tests started failing intermittently because of an Access Denied issue when creating a "test.dat" file. I haven't been able to narrow down why that happened, but one solution is not to write to the disk at all, but store the data in memory (this is relatively easy to do with the storage API).