### PR TITLE
gmtool: clumsy codepage translation

### DIFF
--- a/src/gmtool.c
+++ b/src/gmtool.c
@@ -51,6 +51,7 @@
 #include <items/itemtypes.h>
 
 #include <util/log.h>
+#include <util/unicode.h>
 #include <util/lists.h>
 #include <util/rng.h>
 #include <util/base36.h>
@@ -76,6 +77,40 @@ state *current_state = NULL;
 #define IFL_BUILDINGS (1<<3)
 
 static WINDOW *hstatus;
+
+static void simplify(const char *rp, char *wp) {
+    while (*rp) {
+        if (*rp & 0x80) {
+            while (*rp & 0x80) ++rp;
+            *wp++ = '?';
+        }
+        else {
+            *wp++ = *rp++;
+        }
+    }
+    *wp = 0;
+}
+
+int umvwprintw(WINDOW *win, int y, int x, const char *format, ...) {
+    char buffer[128];
+    int result;
+    va_list args;
+
+    va_start(args, format);
+    memset(buffer, 0, sizeof(buffer));
+    result = vsnprintf(buffer, sizeof(buffer)-1, format, args);
+    va_end(args);
+
+    simplify(buffer, buffer);
+
+    return mvwaddstr(win, y, x, buffer);
+}
+
+int umvwaddnstr(WINDOW *w, int y, int x, const char * str, int len) {
+    char buffer[128];
+    simplify(str, buffer);
+    return mvwaddnstr(w, y, x, buffer, len);
+}
 
 static void init_curses(void)
 {
@@ -354,7 +389,7 @@ static void paint_status(window * wnd, const state * st)
         terrain = mr->r->terrain->_name;
     }
     cnormalize(&st->cursor, &nx, &ny);
-    mvwprintw(win, 0, 0, "%4d %4d | %.4s | %.20s (%d)", nx, ny, terrain, name,
+    umvwprintw(win, 0, 0, "%4d %4d | %.4s | %.20s (%d)", nx, ny, terrain, name,
         uid);
     wclrtoeol(win);
 }
@@ -377,13 +412,13 @@ static void paint_info_region(window * wnd, const state * st)
     if (mr && mr->r) {
         const region *r = mr->r;
         if (r->land) {
-            mvwaddnstr(win, line++, 1, (char *)r->land->name, size);
+            umvwaddnstr(win, line++, 1, (char *)r->land->name, size);
         }
         else {
-            mvwaddnstr(win, line++, 1, r->terrain->_name, size);
+            umvwaddnstr(win, line++, 1, r->terrain->_name, size);
         }
         line++;
-        mvwprintw(win, line++, 1, "%s, age %d", r->terrain->_name, r->age);
+        umvwprintw(win, line++, 1, "%s, age %d", r->terrain->_name, r->age);
         if (r->land) {
             mvwprintw(win, line++, 1, "$:%6d  P:%5d", rmoney(r), rpeasants(r));
             mvwprintw(win, line++, 1, "H:%6d  %s:%5d", rhorses(r),
@@ -398,7 +433,7 @@ static void paint_info_region(window * wnd, const state * st)
             wattroff(win, A_BOLD | COLOR_PAIR(COLOR_YELLOW));
             for (sh = r->ships; sh && line < maxline; sh = sh->next) {
                 mvwprintw(win, line, 1, "%.4s ", itoa36(sh->no));
-                mvwaddnstr(win, line++, 6, (char *)sh->type->_name, size - 5);
+                umvwaddnstr(win, line++, 6, (char *)sh->type->_name, size - 5);
             }
         }
         if (r->units && (st->info_flags & IFL_FACTIONS)) {
@@ -409,7 +444,7 @@ static void paint_info_region(window * wnd, const state * st)
             for (u = r->units; u && line < maxline; u = u->next) {
                 if (!fval(u->faction, FFL_MARK)) {
                     mvwprintw(win, line, 1, "%.4s ", itoa36(u->faction->no));
-                    mvwaddnstr(win, line++, 6, (char *)u->faction->name, size - 5);
+                    umvwaddnstr(win, line++, 6, (char *)u->faction->name, size - 5);
                     fset(u->faction, FFL_MARK);
                 }
             }
@@ -424,7 +459,7 @@ static void paint_info_region(window * wnd, const state * st)
             wattroff(win, A_BOLD | COLOR_PAIR(COLOR_YELLOW));
             for (u = r->units; u && line < maxline; u = u->next) {
                 mvwprintw(win, line, 1, "%.4s ", itoa36(u->no));
-                mvwaddnstr(win, line++, 6, unit_getname(u), size - 5);
+                umvwaddnstr(win, line++, 6, unit_getname(u), size - 5);
             }
         }
     }

--- a/src/gmtool.c
+++ b/src/gmtool.c
@@ -116,12 +116,11 @@ static void simplify(const char *rp, char *wp) {
 
 int umvwprintw(WINDOW *win, int y, int x, const char *format, ...) {
     char buffer[128];
-    int result;
     va_list args;
 
     va_start(args, format);
     memset(buffer, 0, sizeof(buffer));
-    result = vsnprintf(buffer, sizeof(buffer)-1, format, args);
+    vsnprintf(buffer, sizeof(buffer)-1, format, args);
     va_end(args);
 
     simplify(buffer, buffer);

--- a/src/gmtool.h
+++ b/src/gmtool.h
@@ -31,6 +31,7 @@ extern "C" {
   void run_mapper(void);
 
   extern int force_color;
+  extern int gm_codepage;
 
   struct state *state_open(void);
   void state_close(struct state *);

--- a/src/main.c
+++ b/src/main.c
@@ -96,6 +96,7 @@ static void parse_config(const char *filename)
 #ifdef USE_CURSES
         /* only one value in the [editor] section */
         force_color = iniparser_getint(d, "editor:color", force_color);
+        gm_codepage = iniparser_getint(d, "editor:codepage", gm_codepage);
 #endif
     }
 }

--- a/src/util/unicode.c
+++ b/src/util/unicode.c
@@ -518,10 +518,22 @@ size_t * length)
     return 0;
 }
 
+/** Convert a UTF-8 encoded character to ASCII, with '?' replacements. */
+int unicode_utf8_to_ascii(char *cp_character, const utf8_t * utf8_string,
+    size_t *length)
+{
+    int result = unicode_utf8_to_cp437(cp_character, utf8_string, length);
+    if (result == 0) {
+        if (*length > 1) {
+            *cp_character = '?';
+        }
+    }
+    return result;
+}
+
 /** Convert a UTF-8 encoded character to CP1252. */
-int
-unicode_utf8_to_cp1252(char *cp_character, const utf8_t * utf8_string,
-size_t * length)
+int unicode_utf8_to_cp1252(char *cp_character, const utf8_t * utf8_string,
+    size_t * length)
 {
     ucs4_t ucs4_character;
     int result;

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -28,18 +28,20 @@ extern "C" {
     typedef unsigned long ucs4_t;
     typedef char utf8_t;
 
-    extern int unicode_utf8_to_cp437(char *result, const utf8_t * utf8_string,
+    int unicode_utf8_to_cp437(char *result, const utf8_t * utf8_string,
         size_t * length);
-    extern int unicode_utf8_to_cp1252(char *result, const utf8_t * utf8_string,
+    int unicode_utf8_to_cp1252(char *result, const utf8_t * utf8_string,
         size_t * length);
-    extern int unicode_utf8_to_ucs4(ucs4_t * result, const utf8_t * utf8_string,
+    int unicode_utf8_to_ucs4(ucs4_t * result, const utf8_t * utf8_string,
         size_t * length);
-    extern int unicode_ucs4_to_utf8(utf8_t * result, size_t * size,
+    int unicode_ucs4_to_utf8(utf8_t * result, size_t * size,
         ucs4_t ucs4_character);
-    extern int unicode_utf8_strcasecmp(const utf8_t * a, const utf8_t * b);
-    extern int unicode_latin1_to_utf8(utf8_t * out, size_t * outlen,
+    int unicode_utf8_to_ascii(char *cp_character, const utf8_t * utf8_string,
+        size_t *length);
+    int unicode_utf8_strcasecmp(const utf8_t * a, const utf8_t * b);
+    int unicode_latin1_to_utf8(utf8_t * out, size_t * outlen,
         const char *in, size_t * inlen);
-    extern int unicode_utf8_tolower(utf8_t * out, size_t outlen,
+    int unicode_utf8_tolower(utf8_t * out, size_t outlen,
         const utf8_t * in);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixing problems where UTF8 strings are passed to ncurses, which doesn't understand them. Looks great in Windows/pdcurses (CP1252), not perfect in Linux/ncurses.