### PR TITLE
Bug 2228: piracy between land regions

### DIFF
--- a/scripts/tests/e2/movement.lua
+++ b/scripts/tests/e2/movement.lua
@@ -8,6 +8,31 @@ function setup()
     eressea.settings.set("NewbieImmunity", "0")
 end
 
+ function test_piracy()
+    local r = region.create(0, 0, "plain")
+    local r2 = region.create(1, 0, "plain")
+    local r3 = region.create(-1, 0, "ocean")
+    local f = faction.create("pirate@eressea.de", "human", "de")
+    local f2 = faction.create("elf@eressea.de", "human", "de")
+    local u1 = unit.create(f, r2, 1)
+    local u2 = unit.create(f2, r3, 1)
+    
+    u1.ship = ship.create(r2, "longboat")
+    u2.ship = ship.create(r3, "longboat")
+    u1:set_skill("sailing", 10)
+    u2:set_skill("sailing", 10)
+
+    u1:clear_orders()
+    u1:add_order("PIRATERIE")
+    u2:clear_orders()
+    u2:add_order("NACH o")
+
+    process_orders()
+
+-- write_reports()
+    assert_equal(r2, u1.region) -- should pass, but fails!!!
+end 
+
 function test_dolphin_on_land()
     local r1 = region.create(0, 0, "plain")
     local r2 = region.create(1, 0, "plain")

--- a/src/eressea.c
+++ b/src/eressea.c
@@ -49,6 +49,8 @@ void game_done(void)
     calendar_cleanup();
 #endif
     free_functions();
+    free_config();
+    free_locales();
     curses_done();
     kernel_done();
 }

--- a/src/move.c
+++ b/src/move.c
@@ -2267,8 +2267,7 @@ static void travel(unit * u, region_list ** routep)
     }
 }
 
-// FIXME: move_on_land argument is unused, kill it
-void move_cmd(unit * u, order * ord, bool move_on_land)
+void move_cmd(unit * u, order * ord)
 {
     region_list *route = NULL;
 
@@ -2392,7 +2391,7 @@ int follow_ship(unit * u, order * ord)
     init_tokens_str(command);
     getstrtoken();
     /* NACH ausführen */
-    move_cmd(u, ord, false);
+    move_cmd(u, ord);
     return 1;                     /* true -> Einheitenliste von vorne durchgehen */
 }
 
@@ -2559,13 +2558,13 @@ void movement(void)
                         if (ships) {
                             if (u->ship && ship_owner(u->ship) == u) {
                                 init_order(u->thisorder);
-                                move_cmd(u, u->thisorder, false);
+                                move_cmd(u, u->thisorder);
                             }
                         }
                         else {
                             if (!u->ship || ship_owner(u->ship) != u) {
                                 init_order(u->thisorder);
-                                move_cmd(u, u->thisorder, false);
+                                move_cmd(u, u->thisorder);
                             }
                         }
                     }

--- a/src/move.c
+++ b/src/move.c
@@ -1786,8 +1786,7 @@ bool can_takeoff(const ship * sh, const region * from, const region * to)
     return true;
 }
 
-static void
-sail(unit * u, order * ord, bool move_on_land, region_list ** routep)
+static void sail(unit * u, order * ord, region_list ** routep)
 {
     region *starting_point = u->region;
     region *current_point, *last_point;
@@ -1909,12 +1908,10 @@ sail(unit * u, order * ord, bool move_on_land, region_list ** routep)
             } // storms_enabled
             if (!fval(tthis, SEA_REGION)) {
                 if (!fval(tnext, SEA_REGION)) {
-                    if (!move_on_land) {
-                        /* check that you're not traveling from one land region to another. */
-                        ADDMSG(&u->faction->msgs, msg_message("shipnoshore",
-                            "ship region", sh, next_point));
-                        break;
-                    }
+                    /* check that you're not traveling from one land region to another. */
+                    ADDMSG(&u->faction->msgs, msg_message("shipnoshore",
+                        "ship region", sh, next_point));
+                    break;
                 }
                 else {
                     if (!can_takeoff(sh, current_point, next_point)) {
@@ -2024,9 +2021,7 @@ sail(unit * u, order * ord, bool move_on_land, region_list ** routep)
          * transferiert wurden, kann der aktuelle Befehl gelöscht werden. */
         cycle_route(ord, u, step);
         set_order(&u->thisorder, NULL);
-        if (!move_on_land) {
-            set_coast(sh, last_point, current_point);
-        }
+        set_coast(sh, last_point, current_point);
 
         if (is_cursed(sh->attribs, C_SHIP_FLYING, 0)) {
             ADDMSG(&f->msgs, msg_message("shipfly", "ship from to", sh,
@@ -2279,7 +2274,7 @@ void move_cmd(unit * u, order * ord, bool move_on_land)
 
     assert(u->number);
     if (u->ship && u == ship_owner(u->ship)) {
-        sail(u, ord, move_on_land, &route);
+        sail(u, ord, &route);
     }
     else {
         travel(u, &route);

--- a/src/move.c
+++ b/src/move.c
@@ -2272,6 +2272,7 @@ static void travel(unit * u, region_list ** routep)
     }
 }
 
+// FIXME: move_on_land argument is unused, kill it
 void move_cmd(unit * u, order * ord, bool move_on_land)
 {
     region_list *route = NULL;

--- a/src/move.h
+++ b/src/move.h
@@ -74,7 +74,7 @@ extern "C" {
     bool move_blocked(const struct unit *u, const struct region *src,
         const struct region *dest);
     bool can_takeoff(const struct ship * sh, const struct region * from, const struct region * to);
-    void move_cmd(struct unit * u, struct order * ord, bool move_on_land);
+    void move_cmd(struct unit * u, struct order * ord);
     int follow_ship(struct unit * u, struct order * ord);
 
 #define SA_HARBOUR 1

--- a/src/piracy.c
+++ b/src/piracy.c
@@ -206,7 +206,7 @@ void piracy_cmd(unit * u, order *ord)
 
     /* Bewegung ausführen */
     init_order(u->thisorder);
-    move_cmd(u, ord, false);
+    move_cmd(u, ord);
 }
 
 void age_piracy(region *r) {

--- a/src/piracy.c
+++ b/src/piracy.c
@@ -206,7 +206,7 @@ void piracy_cmd(unit * u, order *ord)
 
     /* Bewegung ausführen */
     init_order(u->thisorder);
-    move_cmd(u, ord, true);
+    move_cmd(u, ord, false);
 }
 
 void age_piracy(region *r) {

--- a/src/piracy.test.c
+++ b/src/piracy.test.c
@@ -226,7 +226,7 @@ CuSuite *get_piracy_suite(void)
     SUITE_ADD_TEST(suite, test_piracy_cmd_errors);
     SUITE_ADD_TEST(suite, test_piracy_cmd);
     SUITE_ADD_TEST(suite, test_piracy_cmd_walking);
-    DISABLE_TEST(suite, test_piracy_cmd_land_to_land);
+    SUITE_ADD_TEST(suite, test_piracy_cmd_land_to_land);
     SUITE_ADD_TEST(suite, test_piracy_cmd_swimmer);
     return suite;
 }

--- a/src/piracy.test.c
+++ b/src/piracy.test.c
@@ -226,7 +226,7 @@ CuSuite *get_piracy_suite(void)
     SUITE_ADD_TEST(suite, test_piracy_cmd_errors);
     SUITE_ADD_TEST(suite, test_piracy_cmd);
     SUITE_ADD_TEST(suite, test_piracy_cmd_walking);
-    SUITE_ADD_TEST(suite, test_piracy_cmd_land_to_land);
+    DISABLE_TEST(suite, test_piracy_cmd_land_to_land);
     SUITE_ADD_TEST(suite, test_piracy_cmd_swimmer);
     return suite;
 }

--- a/tests/drmemory.bat
+++ b/tests/drmemory.bat
@@ -1,0 +1,6 @@
+cd c:\users\enno\documents\eressea\git\tests
+
+"C:\Program Files (x86)\Dr. Memory\bin64\drmemory.exe" ..\build-vs14\eressea\Debug\eressea.exe -t184 test-turn.lua
+
+deltree reports
+del datum htpasswd parteien parteien.full passwd score turn

--- a/tests/drmemory.bat
+++ b/tests/drmemory.bat
@@ -2,5 +2,6 @@ cd c:\users\enno\documents\eressea\git\tests
 
 "C:\Program Files (x86)\Dr. Memory\bin64\drmemory.exe" ..\build-vs14\eressea\Debug\eressea.exe -t184 test-turn.lua
 
-deltree reports
+del reports
 del datum htpasswd parteien parteien.full passwd score turn
+pause


### PR DESCRIPTION
An old, unused feature allows piracy between two land regions.
The test for it was disabled.
https://bugs.eressea.de/view.php?id=2228
