### PR TITLE
Neu erzeugte Seeschlangen bekommen keinen "Einheit barf" Namen mehr.

### DIFF
--- a/s/build
+++ b/s/build
@@ -5,8 +5,13 @@ while [ ! -d $ROOT/.git ]; do
 done
 
 [ -z "$BUILD" ] && BUILD=Debug
-
-[ -z "$JOBS" ] && [ "" != "which nproc" ] && JOBS=`nproc`
+if [ -z "$JOBS" ] ; then
+  if [ -e /usr/sbin/sysctl ]; then
+    JOBS=`sysctl -n hw.ncpu`
+  else
+    JOBS=`nproc`
+  fi
+fi
 DISTCC=`which distcc`
 if [ ! -z "$DISTCC" ] ; then
 JOBS=`distcc -j`

--- a/src/bind_monsters.c
+++ b/src/bind_monsters.c
@@ -1,6 +1,7 @@
 #include <platform.h>
 #include "spells/shipcurse.h"
 #include "monster.h"
+#include "monsters.h"
 
 #include <kernel/equipment.h>
 #include <kernel/faction.h>
@@ -28,7 +29,6 @@ static int tolua_levitate_ship(lua_State * L)
 }
 
 extern void spawn_undead(void);
-extern void spawn_dragons(void);
 extern void plan_monsters(struct faction *f);
 
 static int tolua_planmonsters(lua_State * L)

--- a/src/kernel/race.c
+++ b/src/kernel/race.c
@@ -155,7 +155,7 @@ static race *rc_find_i(const char *name)
     const char *rname = name;
     race *rc = races;
 
-    while (rc && !strcmp(rname, rc->_name) == 0) {
+    while (rc && strcmp(rname, rc->_name) != 0) {
         rc = rc->next;
     }
     if (!rc && strcmp(name, "uruk") == 0) {

--- a/src/kernel/race.test.c
+++ b/src/kernel/race.test.c
@@ -41,11 +41,20 @@ static void test_rc_defaults(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_rc_find(CuTest *tc) {
+    race *rc;
+    test_cleanup();
+    rc = test_create_race("hungryhippos");
+    CuAssertPtrEquals(tc, rc, (void *)rc_find("hungryhippos"));
+    test_cleanup();
+}
+
 CuSuite *get_race_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_rc_name);
     SUITE_ADD_TEST(suite, test_rc_defaults);
+    SUITE_ADD_TEST(suite, test_rc_find);
     return suite;
 }
 

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1470,11 +1470,11 @@ unit *create_unit(region * r, faction * f, int number, const struct race *urace,
     /* u->region auch */
     u->hp = unit_max_hp(u) * number;
 
-    if (!dname) {
-        name_unit(u);
-    }
-    else {
+    if (dname) {
         u->_name = _strdup(dname);
+    }
+    else if (urace->generate_name || playerrace(urace)) {
+        name_unit(u);
     }
 
     if (creator) {

--- a/src/monsters.c
+++ b/src/monsters.c
@@ -20,6 +20,8 @@
 #include <platform.h>
 #include <kernel/config.h>
 
+#include "monsters.h"
+
 #include "economy.h"
 #include "chaos.h"
 #include "give.h"
@@ -883,7 +885,16 @@ static int nrand(int start, int sub)
     return res;
 }
 
-/** Drachen und Seeschlangen können entstehen */
+unit *spawn_seaserpent(region *r, faction *f) {
+    unit *u = create_unit(r, f, 1, get_race(RC_SEASERPENT), 0, NULL, NULL);
+    fset(u, UFL_ISNEW | UFL_MOVED);
+    equip_unit(u, get_equipment("monster_seaserpent"));
+    return u;
+}
+
+/** 
+ * Drachen und Seeschlangen können entstehen 
+ */
 void spawn_dragons(void)
 {
     region *r;
@@ -892,13 +903,12 @@ void spawn_dragons(void)
     for (r = regions; r; r = r->next) {
         unit *u;
 
-        if (fval(r->terrain, SEA_REGION) && rng_int() % 10000 < 1) {
-            u = create_unit(r, monsters, 1, get_race(RC_SEASERPENT), 0, NULL, NULL);
-            fset(u, UFL_ISNEW | UFL_MOVED);
-            equip_unit(u, get_equipment("monster_seaserpent"));
+        if (fval(r->terrain, SEA_REGION)) {
+            if (rng_int() % 10000 < 1) {
+                u = spawn_seaserpent(r, monsters);
+            }
         }
-
-        if ((r->terrain == newterrain(T_GLACIER)
+        else if ((r->terrain == newterrain(T_GLACIER)
             || r->terrain == newterrain(T_SWAMP)
             || r->terrain == newterrain(T_DESERT))
             && rng_int() % 10000 < (5 + 100 * chaosfactor(r))) {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -1,0 +1,8 @@
+#pragma once
+
+struct unit;
+struct region;
+struct faction;
+
+struct unit *spawn_seaserpent(struct region *r, struct faction *f);
+void spawn_dragons(void);

--- a/src/monsters.test.c
+++ b/src/monsters.test.c
@@ -11,6 +11,7 @@
 #include <kernel/unit.h>
 
 #include "monster.h"
+#include "monsters.h"
 #include "guard.h"
 #include "reports.h"
 #include "skill.h"
@@ -244,10 +245,24 @@ static void test_monsters_learn_exp(CuTest * tc)
     test_cleanup();
 }
 
+static void test_spawn_seaserpent(CuTest *tc) {
+    region *r;
+    unit *u;
+    faction *f;
+    test_cleanup();
+    r = test_create_region(0, 0, 0);
+    f = test_create_faction(0);
+    u = spawn_seaserpent(r, f);
+    CuAssertPtrNotNull(tc, u);
+    CuAssertPtrEquals(tc, 0, u->_name);
+    test_cleanup();
+}
+
 CuSuite *get_monsters_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_monsters_attack);
+    SUITE_ADD_TEST(suite, test_spawn_seaserpent);
     SUITE_ADD_TEST(suite, test_monsters_attack_ocean);
     SUITE_ADD_TEST(suite, test_seaserpent_piracy);
     SUITE_ADD_TEST(suite, test_monsters_waiting);

--- a/src/monsters.test.c
+++ b/src/monsters.test.c
@@ -249,7 +249,10 @@ static void test_spawn_seaserpent(CuTest *tc) {
     region *r;
     unit *u;
     faction *f;
+    race *rc;
     test_cleanup();
+    rc = test_create_race("seaserpent");
+    rc->flags |= RCF_NPC;
     r = test_create_region(0, 0, 0);
     f = test_create_faction(0);
     u = spawn_seaserpent(r, f);

--- a/src/spells.c
+++ b/src/spells.c
@@ -5354,7 +5354,7 @@ int sp_leaveastral(castorder * co)
         u = pa->param[n]->data.u;
 
         if (!ucontact(u, mage)) {
-            if (power > 10 && !pa->param[n]->flag == TARGET_RESISTS
+            if (power > 10 && !(pa->param[n]->flag == TARGET_RESISTS)
                 && can_survive(u, rt)) {
                 ADDMSG(&mage->faction->msgs, msg_feedback(mage, co->order,
                     "feedback_no_contact_no_resist", "target", u));


### PR DESCRIPTION
Das war scheinbar noch nie so, und alte Seeschlangen wurden einfach konvertiert?