### PR TITLE
remove_unit called by add_recruits crashed the preview

### DIFF
--- a/scripts/tests/common.lua
+++ b/scripts/tests/common.lua
@@ -1139,3 +1139,16 @@ function test_prefix()
     u1.faction.locale = "en"
     assert_not_nil(u1:show():find("archelf"))
 end
+
+function test_recruit()
+    local r = region.create(0, 0, "plain")
+    local f = faction.create("noreply@eressea.de", "human", "de")
+    local u = unit.create(f, r, 1)
+
+    u:add_item("money", 1000)
+    set_order(u, "REKRUTIERE 5")
+    process_orders()
+    for u in f.units do
+        assert_equal(6, u.number)
+    end
+end

--- a/src/economy.c
+++ b/src/economy.c
@@ -244,7 +244,7 @@ static recruitment *select_recruitment(request ** rop,
     return recruits;
 }
 
-static void add_recruits(unit * u, int number, int wanted)
+void add_recruits(unit * u, int number, int wanted)
 {
     region *r = u->region;
     assert(number <= wanted);

--- a/src/economy.h
+++ b/src/economy.h
@@ -61,7 +61,7 @@ extern "C" {
     void give_control(struct unit * u, struct unit * u2);
     void tax_cmd(struct unit * u, struct order *ord, struct request ** taxorders);
     void expandtax(struct region * r, struct request * taxorders);
-
+    void add_recruits(struct unit * u, int number, int wanted);
     struct message * check_steal(const struct unit * u, struct order *ord);
 
 #ifdef __cplusplus

--- a/src/economy.test.c
+++ b/src/economy.test.c
@@ -290,6 +290,22 @@ static void test_maintain_buildings(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_recruit(CuTest *tc) {
+    unit *u;
+    faction *f;
+
+    test_setup();
+    f = test_create_faction(0);
+    u = test_create_unit(f, test_create_region(0, 0, 0));
+    CuAssertIntEquals(tc, 1, u->number);
+    add_recruits(u, 1, 1);
+    CuAssertIntEquals(tc, 2, u->number);
+    CuAssertPtrEquals(tc, u, f->units);
+    CuAssertPtrEquals(tc, NULL, u->nextF);
+    CuAssertPtrEquals(tc, NULL, u->prevF);
+    test_cleanup();
+}
+
 CuSuite *get_economy_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -302,5 +318,6 @@ CuSuite *get_economy_suite(void)
     SUITE_ADD_TEST(suite, test_heroes_dont_recruit);
     SUITE_ADD_TEST(suite, test_tax_cmd);
     SUITE_ADD_TEST(suite, test_maintain_buildings);
+    SUITE_ADD_TEST(suite, test_recruit);
     return suite;
 }

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -439,6 +439,9 @@ int remove_unit(unit ** ulist, unit * u)
         *ulist = u->next;
     }
 
+    if (u->faction && u->faction->units == u) {
+        u->faction->units = u->nextF;
+    }
     if (u->prevF) {
         u->prevF->nextF = u->nextF;
     }


### PR DESCRIPTION
if we keep u->faction set on deleted units, we must still remove the unit from the f->units list.