### PR TITLE
BUG 2266 Fixing FOLLOW

### DIFF
--- a/src/lighthouse.c
+++ b/src/lighthouse.c
@@ -14,7 +14,7 @@
 #include <assert.h>
 #include <math.h>
 
-const attrib_type at_lighthouse = {
+attrib_type at_lighthouse = {
     "lighthouse"
     /* Rest ist NULL; tempor�res, nicht alterndes Attribut */
 };

--- a/src/lighthouse.h
+++ b/src/lighthouse.h
@@ -29,7 +29,7 @@ extern "C" {
     struct building;
     struct attrib;
 
-    extern const struct attrib_type at_lighthouse;
+    extern struct attrib_type at_lighthouse;
     /* leuchtturm */
     bool check_leuchtturm(struct region *r, struct faction *f);
     void update_lighthouse(struct building *lh);

--- a/src/move.c
+++ b/src/move.c
@@ -571,7 +571,7 @@ direction_t reldirection(const region * from, const region * to)
     return NODIRECTION;
 }
 
-static void leave_trail(ship * sh, region * from, region_list * route)
+void leave_trail(ship * sh, region * from, region_list * route)
 {
     region *r = from;
 

--- a/src/move.c
+++ b/src/move.c
@@ -595,7 +595,7 @@ void leave_trail(ship * sh, region * from, region_list * route)
                 a = a->next;
             }
 
-            if (a == NULL) {
+            if (a == NULL || a->type != &at_shiptrail) {
                 a = a_add(&(r->attribs), a_new(&at_shiptrail));
                 td = (traveldir *)a->data.v;
                 td->no = sh->no;

--- a/src/move.h
+++ b/src/move.h
@@ -63,6 +63,8 @@ extern "C" {
     int enoughsailors(const struct ship *sh, int sumskill);
     bool canswim(struct unit *u);
     bool canfly(struct unit *u);
+    void leave_trail(struct ship *sh, struct region *from,
+                            struct region_list *route);
     struct ship *move_ship(struct ship *sh, struct region *from,
     struct region *to, struct region_list *route);
     int walkingcapacity(const struct unit *u);

--- a/src/move.test.c
+++ b/src/move.test.c
@@ -3,6 +3,7 @@
 #include "move.h"
 
 #include "keyword.h"
+#include "lighthouse.h"
 
 #include <kernel/config.h>
 #include <kernel/ally.h>
@@ -501,15 +502,21 @@ static void test_ship_leave_trail(CuTest *tc) {
     test_setup();
     t_ocean = test_create_terrain("ocean", SEA_REGION);
     r1 = test_create_region(0, 0, t_ocean);
-    add_regionlist(&route, r2 = test_create_region(1, 0, t_ocean));
     add_regionlist(&route, test_create_region(2, 0, t_ocean));
+    add_regionlist(&route, r2 = test_create_region(1, 0, t_ocean));
     st_boat = test_create_shiptype("boat");
     s1 = test_create_ship(r1, st_boat);
     s2 = test_create_ship(r1, st_boat);
     leave_trail(s1, r1, route);
+    a_add(&r1->attribs, a_new(&at_lighthouse));
     leave_trail(s2, r1, route);
-//    CuAssertPtrNotNull(tc, r1->attribs);
-    CuAssertPtrNotNull(tc, r2->attribs);
+    a_add(&r2->attribs, a_new(&at_lighthouse));
+    CuAssertPtrEquals(tc, &at_shiptrail, (void *)r1->attribs->type);
+    CuAssertPtrEquals(tc, &at_shiptrail, (void *)r1->attribs->next->type);
+    CuAssertPtrEquals(tc, &at_lighthouse, (void *)r1->attribs->next->next->type);
+    CuAssertPtrEquals(tc, &at_shiptrail, (void *)r2->attribs->type);
+    CuAssertPtrEquals(tc, &at_shiptrail, (void *)r2->attribs->next->type);
+    CuAssertPtrEquals(tc, &at_lighthouse, (void *)r2->attribs->next->next->type);
     free_regionlist(route);
     test_cleanup();
 }

--- a/src/move.test.c
+++ b/src/move.test.c
@@ -478,7 +478,7 @@ static void test_drifting_ships(CuTest *tc) {
     region *r1, *r2, *r3;
     terrain_type *t_ocean, *t_plain;
     ship_type *st_boat;
-    test_cleanup();
+    test_setup();
     t_ocean = test_create_terrain("ocean", SEA_REGION);
     t_plain = test_create_terrain("plain", LAND_REGION);
     r1 = test_create_region(0, 0, t_ocean);
@@ -491,11 +491,35 @@ static void test_drifting_ships(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_ship_leave_trail(CuTest *tc) {
+    ship *s1, *s2;
+    region *r1, *r2;
+    terrain_type *t_ocean;
+    ship_type *st_boat;
+    region_list *route = NULL;
+
+    test_setup();
+    t_ocean = test_create_terrain("ocean", SEA_REGION);
+    r1 = test_create_region(0, 0, t_ocean);
+    add_regionlist(&route, r2 = test_create_region(1, 0, t_ocean));
+    add_regionlist(&route, test_create_region(2, 0, t_ocean));
+    st_boat = test_create_shiptype("boat");
+    s1 = test_create_ship(r1, st_boat);
+    s2 = test_create_ship(r1, st_boat);
+    leave_trail(s1, r1, route);
+    leave_trail(s2, r1, route);
+//    CuAssertPtrNotNull(tc, r1->attribs);
+    CuAssertPtrNotNull(tc, r2->attribs);
+    free_regionlist(route);
+    test_cleanup();
+}
+
 CuSuite *get_move_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_walkingcapacity);
     SUITE_ADD_TEST(suite, test_ship_not_allowed_in_coast);
+    SUITE_ADD_TEST(suite, test_ship_leave_trail);
     SUITE_ADD_TEST(suite, test_ship_allowed_without_harbormaster);
     SUITE_ADD_TEST(suite, test_ship_blocked_by_harbormaster);
     SUITE_ADD_TEST(suite, test_ship_has_harbormaster_contact);


### PR DESCRIPTION
If a region had another shiptrail attribute, as well as a being seen by a lighthouse, then new trails were not being added.
https://bugs.eressea.de/view.php?id=2266