### PR TITLE
disable config.lua auto-laod

### DIFF
--- a/scripts/tests/laws.lua
+++ b/scripts/tests/laws.lua
@@ -95,6 +95,7 @@ function test_force_leave_postcombat()
     u1.building = b1
     u2.building = b1
     eressea.settings.set("rules.owners.force_leave", "1")
+    eressea.settings.set("NewbieImmunity", "0")
     u1:clear_orders()
     u1:add_order("ATTACKIERE " .. itoa36(u2.id))
     u2:clear_orders()
@@ -109,6 +110,7 @@ function test_force_leave_postcombat()
         end
     end
     assert_not_equal(nil, u3)
+    assert_equal(nil, u2.building)
     assert_equal(nil, u3.building)
     assert_equal(1, u3.number)
 end

--- a/scripts/tests/xmas.lua
+++ b/scripts/tests/xmas.lua
@@ -8,6 +8,8 @@ function setup()
     eressea.settings.set("rules.grow.formula", "0")
     eressea.settings.set("rules.peasants.growth.factor", "0")
     eressea.settings.set("volcano.active.percent", "0")
+    eressea.settings.set("volcano.outbreak.percent", "0")
+    eressea.settings.set("volcano.stop.percent", "0")
 end
 
 function test_snowglobe_fail()

--- a/src/bind_config.c
+++ b/src/bind_config.c
@@ -4,6 +4,7 @@
 #include <kernel/config.h>
 #include <kernel/jsonconf.h>
 #include <util/bsdstring.h>
+#include <util/nrmessage.h>
 #include <util/log.h>
 #include <util/language.h>
 #include <cJSON.h>
@@ -20,7 +21,9 @@
 
 void config_reset(void) {
     default_locale = 0;
+    free_config();
     free_locales();
+    free_nrmesssages();
     free_spells();
     free_buildingtypes();
     free_shiptypes();

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -1190,7 +1190,7 @@ int eressea_run(lua_State *L, const char *luafile)
     lua_remove(L, -2);
 
     /* try to run configuration scripts: */
-    err = run_script(L, "config.lua");
+    // err = run_script(L, "config.lua");
     err = run_script(L, "custom.lua");
 
     /* run the main script */

--- a/src/laws.c
+++ b/src/laws.c
@@ -119,7 +119,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 int NewbieImmunity(void)
 {
-    return config_get_int("NewbieImmunity", 0);
+    int result = config_get_int("NewbieImmunity", 0);
+    return result;
 }
 
 bool IsImmune(const faction * f)

--- a/src/util/nrmessage.c
+++ b/src/util/nrmessage.c
@@ -178,3 +178,16 @@ const char *nrt_section(const nrmessage_type * nrt)
 {
     return nrt ? nrt->section : NULL;
 }
+
+void free_nrmesssages(void) {
+    int i;
+    for (i = 0; i != NRT_MAXHASH; ++i) {
+        while (nrtypes[i]) {
+            nrmessage_type *nr = nrtypes[i];
+            nrtypes[i] = nr->next;
+            free(nr->string);
+            free(nr->vars);
+            free(nr);
+        }
+    }
+}

--- a/src/util/nrmessage.h
+++ b/src/util/nrmessage.h
@@ -31,18 +31,20 @@ extern "C" {
 
     extern nrsection *sections;
 
-    extern void nrt_register(const struct message_type *mtype,
+    void free_nrmesssages(void);
+
+    void nrt_register(const struct message_type *mtype,
         const struct locale *lang, const char *script,
         int level, const char *section);
-    extern struct nrmessage_type *nrt_find(const struct locale *,
+    struct nrmessage_type *nrt_find(const struct locale *,
         const struct message_type *);
-    extern const char *nrt_string(const struct nrmessage_type *type);
-    extern const char *nrt_section(const struct nrmessage_type *mt);
+    const char *nrt_string(const struct nrmessage_type *type);
+    const char *nrt_section(const struct nrmessage_type *mt);
 
-    extern size_t nr_render(const struct message *msg, const struct locale *lang,
+    size_t nr_render(const struct message *msg, const struct locale *lang,
         char *buffer, size_t size, const void *userdata);
-    extern int nr_level(const struct message *msg);
-    extern const char *nr_section(const struct message *msg);
+    int nr_level(const struct message *msg);
+    const char *nr_section(const struct message *msg);
 
     /* before:
      * fogblock;movement:0;de;{unit} konnte von {region} nicht nach {$dir direction} ausreisen, der Nebel war zu dicht.

--- a/src/util/nrmessage_struct.h
+++ b/src/util/nrmessage_struct.h
@@ -8,8 +8,8 @@
 typedef struct nrmessage_type {
   const struct message_type *mtype;
   const struct locale *lang;
-  const char *string;
-  const char *vars;
+  char *string;
+  char *vars;
   struct nrmessage_type *next;
   int level;
   const char *section;

--- a/src/volcano.c
+++ b/src/volcano.c
@@ -256,11 +256,19 @@ void volcano_outbreak(region * r, region *rn)
 }
 
 static bool stop_smoke_chance(void) {
-    return rng_int() % 100 < 12;
+    static int cache, percent = 0;
+    if (config_changed(&cache)) {
+        percent = config_get_int("volcano.stop.percent", 12);
+    }
+    return percent!=0 && (rng_int() % 100) < percent;
 }
 
 static bool outbreak_chance(void) {
-    return rng_int() % 100 < 8;
+    static int cache, percent = 0;
+    if (config_changed(&cache)) {
+        percent = config_get_int("volcano.outbreak.percent", 8);
+    }
+    return percent!=0 && (rng_int() % 100) < percent;
 }
 
 void volcano_update(void) 


### PR DESCRIPTION
It was breaking tests in complicated ways. I'll re-enable it when I can figure out how to work around this.
Fix issue #637 