### PR TITLE
BUG 2273: runtests.bat fails when config is auto-loaded.

### DIFF
--- a/scripts/tests/e3/castles.lua
+++ b/scripts/tests/e3/castles.lua
@@ -46,7 +46,7 @@ end
 
 function test_build_packice()
 	local r = region.create(0, 0, "packice")
-	local f = faction.create("noreply@eressea.de", "human", "de")
+	local f = faction.create("packice@eressea.de", "human", "de")
 	local u = unit.create(f, r, 1)
     u:clear_orders()
     u:add_item("stone", 10)

--- a/tests/runtests.bat
+++ b/tests/runtests.bat
@@ -6,9 +6,9 @@ IF EXIST ..\build-vs14 SET BUILD=..\build-vs14\eressea\Debug
 SET SERVER=%BUILD%\eressea.exe
 %BUILD%\test_eressea.exe
 %SERVER% ..\scripts\run-tests.lua
-%SERVER% ..\scripts\run-tests-e2.lua
-%SERVER% ..\scripts\run-tests-e3.lua
-%SERVER% ..\scripts\run-tests-e4.lua
+%SERVER% -re2 ..\scripts\run-tests-e2.lua
+%SERVER% -re3 ..\scripts\run-tests-e3.lua
+%SERVER% -re4 ..\scripts\run-tests-e4.lua
 PAUSE
 RMDIR /s /q reports
 DEL score score.alliances datum turn


### PR DESCRIPTION
run rules tests with the correct configuration, ignore .ini file
setting.
still not enabling auto-load again, use custom.lua instead.