### PR TITLE
BUG 2274: Bestimmung des Regionsbesitz bei BENENNE 

### DIFF
--- a/src/kernel/building.c
+++ b/src/kernel/building.c
@@ -335,7 +335,18 @@ const building_type *findbuildingtype(const char *name,
     return (const building_type *)type.v;
 }
 
-static int building_protection(const building * b, const unit * u, building_bonus bonus)
+int cmp_castle_size(const building * b, const building * a)
+{
+    if (!b || !b->type->protection || !building_owner(b)) {
+        return -1;
+    }
+    if (!a || !a->type->protection || !building_owner(a)) {
+        return 1;
+    }
+    return b->size - a->size;
+}
+
+int building_protection(const building * b, const unit * u, building_bonus bonus)
 {
     int i = 0;
     int bsize = buildingeffsize(b, false);

--- a/src/kernel/building.h
+++ b/src/kernel/building.h
@@ -85,6 +85,8 @@ extern "C" {
     extern struct quicklist *buildingtypes;
     extern struct attrib_type at_building_action;
 
+    int cmp_castle_size(const struct building * b, const struct building * a);
+    int building_protection(const struct building * b, const struct unit * u, building_bonus bonus);
     building_type *bt_get_or_create(const char *name);
     bool bt_changed(int *cache);
     const building_type *bt_find(const char *name);

--- a/src/kernel/building.test.c
+++ b/src/kernel/building.test.c
@@ -493,9 +493,35 @@ static void test_building_type(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_cmp_castle_size(CuTest *tc) {
+    region *r;
+    building *b1, *b2;
+    building_type *bt_castle;
+    unit *u1, *u2;
+
+    test_setup();
+    bt_castle = test_create_buildingtype("castle");
+    bt_castle->protection = building_protection;
+    r = test_create_region(0, 0, 0);
+    b1 = test_create_building(r, bt_castle);
+    b2 = test_create_building(r, bt_castle);
+    u1 = test_create_unit(test_create_faction(0), r);
+    u_set_building(u1, b1);
+    u2 = test_create_unit(test_create_faction(0), r);
+    u_set_building(u2, b2);
+    b1->size = 5;
+    b2->size = 10;
+    CuAssertTrue(tc, cmp_castle_size(b1, b2)<0);
+    CuAssertTrue(tc, cmp_castle_size(b2, b1)>0);
+    CuAssertTrue(tc, cmp_castle_size(b1, NULL)>0);
+    CuAssertTrue(tc, cmp_castle_size(NULL, b1)<0);
+    test_cleanup();
+}
+
 CuSuite *get_building_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
+    SUITE_ADD_TEST(suite, test_cmp_castle_size);
     SUITE_ADD_TEST(suite, test_register_building);
     SUITE_ADD_TEST(suite, test_btype_defaults);
     SUITE_ADD_TEST(suite, test_building_set_owner);

--- a/src/kernel/building.test.c
+++ b/src/kernel/building.test.c
@@ -496,15 +496,12 @@ static void test_building_type(CuTest *tc) {
 static void test_cmp_castle_size(CuTest *tc) {
     region *r;
     building *b1, *b2;
-    building_type *bt_castle;
     unit *u1, *u2;
 
     test_setup();
-    bt_castle = test_create_buildingtype("castle");
-    bt_castle->protection = building_protection;
     r = test_create_region(0, 0, 0);
-    b1 = test_create_building(r, bt_castle);
-    b2 = test_create_building(r, bt_castle);
+    b1 = test_create_building(r, NULL);
+    b2 = test_create_building(r, NULL);
     u1 = test_create_unit(test_create_faction(0), r);
     u_set_building(u1, b1);
     u2 = test_create_unit(test_create_faction(0), r);

--- a/src/kernel/config.c
+++ b/src/kernel/config.c
@@ -204,7 +204,7 @@ param_t findparam(const char *s, const struct locale * lang)
         void **tokens = get_translations(lang, UT_PARAMS);
         critbit_tree *cb = (critbit_tree *)*tokens;
         if (!cb) {
-            log_error("no parameters defined in locale %s", locale_name(lang));
+            log_warning("no parameters defined in locale %s", locale_name(lang));
         }
         else if (cb_find_prefix(cb, str, strlen(str), &match, 1, 0)) {
             cb_get_kv(match, &i, sizeof(int));

--- a/src/kernel/region.c
+++ b/src/kernel/region.c
@@ -1324,9 +1324,17 @@ struct message *msg)
 
 struct faction *region_get_owner(const struct region *r)
 {
-    assert(rule_region_owners());
-    if (r->land && r->land->ownership) {
-        return r->land->ownership->owner;
+    if (r->land) {
+        if (rule_region_owners()) {
+            if (r->land->ownership) {
+                return r->land->ownership->owner;
+            }
+        }
+        else {
+            building *b = largestbuilding(r, cmp_castle_size, false);
+            unit * u = b ? building_owner(b) : NULL;
+            return u ? u->faction : NULL;
+        }
     }
     return NULL;
 }

--- a/src/kernel/region.test.c
+++ b/src/kernel/region.test.c
@@ -1,6 +1,8 @@
 #include <platform.h>
 
 #include "region.h"
+#include "building.h"
+#include "unit.h"
 #include "terrain.h"
 #include "item.h"
 
@@ -31,9 +33,32 @@ void test_terraform(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_region_get_owner(CuTest *tc) {
+    region *r;
+    building *b1, *b2;
+    building_type *bt_castle;
+    unit *u1, *u2;
+
+    test_setup();
+    bt_castle = test_create_buildingtype("castle");
+    bt_castle->protection = building_protection;
+    r = test_create_region(0, 0, 0);
+    b1 = test_create_building(r, bt_castle);
+    b2 = test_create_building(r, bt_castle);
+    b1->size = 5;
+    b2->size = 10;
+    u1 = test_create_unit(test_create_faction(0), r);
+    u_set_building(u1, b1);
+    u2 = test_create_unit(test_create_faction(0), r);
+    u_set_building(u2, b2);
+    CuAssertPtrEquals(tc, u2->faction, region_get_owner(r));
+    test_cleanup();
+}
+
 CuSuite *get_region_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_terraform);
+    SUITE_ADD_TEST(suite, test_region_get_owner);
     return suite;
 }

--- a/src/kernel/region.test.c
+++ b/src/kernel/region.test.c
@@ -36,15 +36,12 @@ void test_terraform(CuTest *tc) {
 static void test_region_get_owner(CuTest *tc) {
     region *r;
     building *b1, *b2;
-    building_type *bt_castle;
     unit *u1, *u2;
 
     test_setup();
-    bt_castle = test_create_buildingtype("castle");
-    bt_castle->protection = building_protection;
     r = test_create_region(0, 0, 0);
-    b1 = test_create_building(r, bt_castle);
-    b2 = test_create_building(r, bt_castle);
+    b1 = test_create_building(r, NULL);
+    b2 = test_create_building(r, NULL);
     b1->size = 5;
     b2->size = 10;
     u1 = test_create_unit(test_create_faction(0), r);

--- a/src/laws.c
+++ b/src/laws.c
@@ -1538,16 +1538,6 @@ int prefix_cmd(unit * u, struct order *ord)
     return 0;
 }
 
-static cmp_building_cb get_cmp_region_owner(void)
-{
-    if (rule_region_owners()) {
-        return &cmp_current_owner;
-    }
-    else {
-        return &cmp_wage;
-    }
-}
-
 int display_cmd(unit * u, struct order *ord)
 {
     char token[128];
@@ -1597,15 +1587,7 @@ int display_cmd(unit * u, struct order *ord)
         break;
 
     case P_REGION:
-        if (!u->building) {
-            cmistake(u, ord, 145, MSG_EVENT);
-            break;
-        }
-        if (building_owner(u->building) != u) {
-            cmistake(u, ord, 148, MSG_EVENT);
-            break;
-        }
-        if (u->building != largestbuilding(r, get_cmp_region_owner(), false)) {
+        if (u->faction != region_get_owner(r)) {
             cmistake(u, ord, 147, MSG_EVENT);
             break;
         }

--- a/src/laws.c
+++ b/src/laws.c
@@ -1892,16 +1892,7 @@ int name_cmd(struct unit *u, struct order *ord)
         break;
 
     case P_REGION:
-        if (!b) {
-            cmistake(u, ord, 145, MSG_EVENT);
-            break;
-        }
-        if (building_owner(b) != u) {
-            cmistake(u, ord, 148, MSG_EVENT);
-            break;
-        }
-
-        if (b != largestbuilding(r, get_cmp_region_owner(), false)) {
+        if (u->faction != region_get_owner(r)) {
             cmistake(u, ord, 147, MSG_EVENT);
             break;
         }

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -229,6 +229,11 @@ static void test_display_cmd(CuTest *tc) {
     CuAssertPtrEquals(tc, NULL, u->display);
     free_order(ord);
 
+    ord = create_order(K_DISPLAY, f->locale, "%s Hodor", LOC(f->locale, parameters[P_REGION]));
+    CuAssertIntEquals(tc, 0, display_cmd(u, ord));
+    CuAssertPtrEquals(tc, NULL, r->display);
+    free_order(ord);
+
     test_cleanup();
 }
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -225,8 +225,13 @@ building * test_create_building(region * r, const building_type * btype)
 {
     building * b;
     assert(r);
-    b = new_building(btype ? btype : test_create_buildingtype("castle"), r, default_locale);
-    b->size = b->type->maxsize > 0 ? b->type->maxsize : 1;
+    if (!btype) {
+        building_type *bt_castle = test_create_buildingtype("castle");
+        bt_castle->protection = building_protection;
+        btype = bt_castle;
+    }
+    b = new_building(btype, r, default_locale);
+    b->size = btype->maxsize > 0 ? btype->maxsize : 1;
     return b;
 }
 


### PR DESCRIPTION
BENENNE und BESCHREIBE haben die Feststellung der größten Burg falsch gemacht, das ist repariert. Bei der Gelegenheit habe ich region_get_owner für E2 eingebaut.