### PR TITLE
Bug 2253: never give mages to another unit

### DIFF
--- a/conf/e2/locales.xml
+++ b/conf/e2/locales.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<eressea xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="config://core/messages.xml"/>
+  <xi:include href="config://core/de/strings.xml"/>
+  <xi:include href="config://core/en/strings.xml"/>
+  <xi:include href="config://game/spellinfo.xml" />
+  <xi:include href="config://default/names-undead.xml"/>
+  <xi:include href="config://default/names-skeletons.xml"/>
+  <xi:include href="config://default/names-zombies.xml"/>
+  <xi:include href="config://default/names-ghouls.xml"/>
+  <xi:include href="config://default/names-dragons.xml"/>
+</eressea>

--- a/src/give.c
+++ b/src/give.c
@@ -227,7 +227,7 @@ static bool can_give_men(const unit *u, const unit *dst, order *ord, message **m
     if (unit_has_cursed_item(u)) {
         if (msg) *msg = msg_error(u, ord, 78);
     }
-    else if (dst && (has_skill(u, SK_MAGIC) && dst->number > 0)) {
+    else if (has_skill(u, SK_MAGIC)) {
         /* cannot give units to and from magicians */
         if (msg) *msg = msg_error(u, ord, 158);
     }

--- a/src/give.test.c
+++ b/src/give.test.c
@@ -124,12 +124,6 @@ static void test_give_men_magicians(CuTest * tc) {
     CuAssertIntEquals(tc, 1, env.src->number);
     msg_release(msg);
 
-
-    set_number(env.dst, 0);
-    CuAssertPtrEquals(tc, NULL, give_men(1, env.src, env.dst, NULL));
-    CuAssertIntEquals(tc, 1, env.dst->number);
-    CuAssertIntEquals(tc, 0, env.src->number);
-
     p = rpeasants(env.r);
     CuAssertPtrNotNull(tc, msg = disband_men(1, env.dst, NULL));
     CuAssertStrEquals(tc, "give_person_peasants", (const char *)msg->parameters[0].v);

--- a/src/kernel/curse.h
+++ b/src/kernel/curse.h
@@ -210,7 +210,7 @@ extern "C" {
     typedef struct curse {
         variant data;               /* pointer auf spezielle curse-unterstructs */
         struct curse *nexthash;
-        const curse_type *type;      /* Zeiger auf ein curse_type-struct */
+        const curse_type *type;     /* Zeiger auf ein curse_type-struct */
         struct unit *magician;      /* Pointer auf den Magier, der den Spruch gewirkt hat */
         double vigour;              /* Stärke der Verzauberung, Widerstand gegen Antimagie */
         double effect;

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1245,24 +1245,6 @@ static int item_invis(const unit *u) {
         + (rsphere ? i_get(u->items, rsphere->itype) * 100 : 0);
 }
 
-#ifdef NEWATSROI
-static int item_modification(const unit * u, skill_t sk, int val)
-{
-    if (sk == SK_STEALTH) {
-        if (item_invis(u) >= u->number) {
-            val += ROIBONUS;
-        }
-    }
-    if (sk == SK_PERCEPTION) {
-        const struct resource_type *rtype = get_resourcetype(R_AMULET_OF_TRUE_SEEING);
-        if (i_get(u->items, rtype->itype) >= u->number) {
-            val += ATSBONUS;
-        }
-    }
-    return val;
-}
-#endif
-
 static int att_modification(const unit * u, skill_t sk)
 {
     double result = 0;
@@ -1335,11 +1317,6 @@ int get_modifier(const unit * u, skill_t sk, int level, const region * r, bool n
     skill += rc_skillmod(u_race(u), r, sk);
     skill += att_modification(u, sk);
 
-#ifdef NEWATSROI
-    if (!noitem) {
-        skill = item_modification(u, sk, skill);
-    }
-#endif
     skill = skillmod(u->attribs, u, r, sk, skill, SMF_ALWAYS);
 
     if (fval(u, UFL_HUNGER)) {
@@ -1382,9 +1359,6 @@ int effskill_study(const unit * u, skill_t sk, const region * r)
 
 int invisible(const unit * target, const unit * viewer)
 {
-#ifdef NEWATSROI
-    return 0;
-#else
     if (viewer && viewer->faction == target->faction)
         return 0;
     else {
@@ -1398,7 +1372,6 @@ int invisible(const unit * target, const unit * viewer)
         }
         return hidden;
     }
-#endif
 }
 
 /** remove the unit from memory.

--- a/src/kernel/unit.c
+++ b/src/kernel/unit.c
@@ -1301,7 +1301,7 @@ static int att_modification(const unit * u, skill_t sk)
             while (a && a->type == &at_curse) {
                 curse *c = (curse *)a->data.v;
 
-                if (curse_active(c) && c->type == gbdream_ct) {
+                if (c->magician && curse_active(c) && c->type == gbdream_ct) {
                     int effect = curse_geteffect_int(c);
                     bool allied = alliedunit(c->magician, u->faction, HELP_GUARD);
                     if (allied) {

--- a/src/spells.c
+++ b/src/spells.c
@@ -4726,7 +4726,7 @@ static int sp_gbdreams(castorder * co, const char *curse_name, int effect)
 
     /* Erfolg melden */
     ADDMSG(&mage->faction->msgs, msg_message("regionmagic_effect",
-        "unit region command", c->magician, mage->region, co->order));
+        "unit region command", mage, mage->region, co->order));
 
     return cast_level;
 }
@@ -4867,7 +4867,7 @@ int sp_sweetdreams(castorder * co)
         effect = 0.05f;
         c = create_curse(mage, &u->attribs, ct_find("orcish"), power, duration, effect, men);
 
-        msg = msg_message("sp_sweetdreams_effect", "mage unit region", c->magician, u, r);
+        msg = msg_message("sp_sweetdreams_effect", "mage unit region", mage, u, r);
         r_addmessage(r, mage->faction, msg);
         if (u->faction != mage->faction) {
             r_addmessage(r, u->faction, msg);
@@ -4892,7 +4892,7 @@ int sp_disturbingdreams(castorder * co)
     c = create_curse(mage, &r->attribs, ct_find("badlearn"), power, duration, effect, 0);
 
     ADDMSG(&mage->faction->msgs, msg_message("sp_disturbingdreams_effect",
-        "mage region", c->magician, r));
+        "mage region", mage, r));
     return cast_level;
 }
 

--- a/src/spells.c
+++ b/src/spells.c
@@ -4714,7 +4714,6 @@ static int sp_gbdreams(castorder * co, const char *curse_name, int effect)
     int cast_level = co->level;
     double power = co->force;
     region *r = co_get_region(co);
-    curse *c;
 
     /* wirkt erst in der Folgerunde, soll mindestens eine Runde wirken,
      * also duration+2 */
@@ -4722,8 +4721,8 @@ static int sp_gbdreams(castorder * co, const char *curse_name, int effect)
     duration = 2 + rng_int() % duration;
 
     /* Nichts machen als ein entsprechendes Attribut in die Region legen. */
-    c = create_curse(mage, &r->attribs, ct_find(curse_name), power, duration, effect, 0);
-
+    create_curse(mage, &r->attribs, ct_find(curse_name), power, duration, effect, 0);
+    
     /* Erfolg melden */
     ADDMSG(&mage->faction->msgs, msg_message("regionmagic_effect",
         "unit region command", mage, mage->region, co->order));
@@ -4841,7 +4840,6 @@ int sp_sweetdreams(castorder * co)
 
     /* Schleife ueber alle angegebenen Einheiten */
     for (n = 0; n < pa->length; n++) {
-        curse *c;
         unit *u;
         double effect;
         message *msg;
@@ -4865,7 +4863,7 @@ int sp_sweetdreams(castorder * co)
 
         /* Nichts machen als ein entsprechendes Attribut an die Einheit legen. */
         effect = 0.05f;
-        c = create_curse(mage, &u->attribs, ct_find("orcish"), power, duration, effect, men);
+        create_curse(mage, &u->attribs, ct_find("orcish"), power, duration, effect, men);
 
         msg = msg_message("sp_sweetdreams_effect", "mage unit region", mage, u, r);
         r_addmessage(r, mage->faction, msg);
@@ -4886,10 +4884,9 @@ int sp_disturbingdreams(castorder * co)
     double power = co->force;
     int duration = 1 + (int)(power / 6);
     double effect;
-    curse *c;
 
     effect = 10;
-    c = create_curse(mage, &r->attribs, ct_find("badlearn"), power, duration, effect, 0);
+    create_curse(mage, &r->attribs, ct_find("badlearn"), power, duration, effect, 0);
 
     ADDMSG(&mage->faction->msgs, msg_message("sp_disturbingdreams_effect",
         "mage region", mage, r));


### PR DESCRIPTION
undo changes made for https://bugs.eressea.de/view.php?id=2253, revert to pre-3.10 behavior.