### PR TITLE
BUG 2337: new lighthouse capacity calculation

### DIFF
--- a/conf/e2/config.json
+++ b/conf/e2/config.json
@@ -35,6 +35,7 @@
         "rules.guard.guard_number_stop_prob": 0.001,
         "rules.guard.castle_stop_prob": 0.05,
         "rules.guard.region_type_stop_prob": 0.05,
-        "rules.economy.repopulate_maximum": 500
+        "rules.economy.repopulate_maximum": 500,
+        "rules.lighthouse.unit_capacity": true
     }
 }

--- a/conf/e3/config.json
+++ b/conf/e3/config.json
@@ -92,6 +92,7 @@
         "rules.grow.formula": 1,
         "rules.tactics.formula": 1,
         "rules.help.mask": "fight guard money give",
+        "rules.lighthouse.unit_capacity": true,
         "movement.shipspeed.skillbonus": 6,
         "alliance.auto": "fight",
         "alliance.restricted": "fight"

--- a/res/buildings/castle-2.xml
+++ b/res/buildings/castle-2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<building name="castle" capacity="1" fort="yes" taxes="100">
+<building name="castle" fort="yes" taxes="100">
   <construction skill="building" minskill="1" maxsize="10" name="site">
     <requirement type="stone" quantity="1"/>
   </construction>

--- a/res/buildings/castle.xml
+++ b/res/buildings/castle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<building name="castle" capacity="1" fort="yes">
+<building name="castle" fort="yes">
   <construction skill="building" minskill="1" maxsize="2" name="site">
     <requirement type="stone" quantity="1"/>
   </construction>

--- a/res/core/common/buildings.xml
+++ b/res/core/common/buildings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <buildings>
-  <building name="wormhole" maxsize="4" capacity="1" maxcapacity="4" nobuild="yes" nodestroy="yes" unique="yes" />
+  <building name="wormhole" maxsize="4" maxcapacity="4" nobuild="yes" nodestroy="yes" unique="yes" />
   <building name="illusioncastle" capacity="0" maxcapacity="0" maxsize="0" nobuild="yes"/>
   <building name="xmas_exit" maxsize="10" maxcapacity="2" nobuild="yes" nodestroy="yes" unique="yes"/>
-  <building name="caldera" capacity="1" nodestroy="yes" nobuild="yes"/>
+  <building name="caldera" nodestroy="yes" nobuild="yes"/>
   <building name="building" namechange="no" maxsize="1" nobuild="yes"/>
 
   <building name="blessedstonecircle" maxcapacity="3" maxsize="100" nobuild="yes" magic="yes" magres="60" magresbonus="30" auraregen="1.50">
@@ -20,7 +20,7 @@
     </construction>
   </building>
 
-  <building name="inn" capacity="1">
+  <building name="inn">
     <maintenance type="money" amount="5" variable="yes"/>
     <construction skill="building" minskill="2" reqsize="10">
       <requirement type="iron" quantity="10"/>
@@ -30,7 +30,7 @@
     </construction>
   </building>
 
-  <building name="tunnel" capacity="1" maxsize="100">
+  <building name="tunnel" maxsize="100">
     <maintenance type="stone" amount="2"/>
     <maintenance type="money" amount="100"/>
     <construction skill="building" minskill="6" reqsize="100">
@@ -41,7 +41,7 @@
     </construction>
   </building>
 
-  <building name="caravan" capacity="1" maxsize="10">
+  <building name="caravan" maxsize="10">
     <maintenance type="horse" amount="2"/>
     <maintenance type="money" amount="3000"/>
     <construction skill="building" minskill="2" reqsize="10">
@@ -52,7 +52,7 @@
     </construction>
   </building>
 
-  <building name="dam" capacity="1" maxsize="50">
+  <building name="dam" maxsize="50">
     <maintenance type="log" amount="3"/>
     <maintenance type="money" amount="1000"/>
     <construction skill="building" minskill="4" reqsize="50">
@@ -63,7 +63,7 @@
     </construction>
   </building>
 
-  <building name="monument" namechange="no" capacity="1">
+  <building name="monument" namechange="no">
     <construction skill="building" minskill="4">
       <requirement type="log" quantity="1"/>
       <requirement type="stone" quantity="1"/>
@@ -72,7 +72,7 @@
     </construction>
   </building>
 
-  <building name="stables" capacity="1">
+  <building name="stables">
     <maintenance type="money" amount="150"/>
     <construction skill="building" minskill="2">
       <requirement type="log" quantity="4"/>
@@ -82,7 +82,7 @@
     </construction>
   </building>
 
-  <building name="sawmill" capacity="1">
+  <building name="sawmill">
     <maintenance type="money" amount="250"/>
     <construction skill="building" minskill="3">
       <requirement type="log" quantity="5"/>
@@ -92,7 +92,7 @@
     </construction>
   </building>
 
-  <building name="smithy" capacity="1">
+  <building name="smithy">
     <maintenance type="money" amount="300"/>
     <maintenance type="log" amount="1"/>
     <construction skill="building" minskill="3">
@@ -127,7 +127,7 @@
     </construction>
   </building>
 
-  <building name="harbour" capacity="1" maxcapacity="25" maxsize="25" unique="yes">
+  <building name="harbour" maxcapacity="25" maxsize="25" unique="yes">
     <maintenance type="money" amount="250"/>
     <construction skill="building" minskill="3" reqsize="25">
       <requirement type="log" quantity="125"/>
@@ -136,7 +136,7 @@
     </construction>
   </building>
 
-  <building name="quarry" capacity="1">
+  <building name="quarry">
     <maintenance type="money" amount="250"/>
     <construction skill="building" minskill="2">
       <requirement type="iron" quantity="1"/>
@@ -146,7 +146,7 @@
     </construction>
   </building>
 
-  <building name="mine" capacity="1">
+  <building name="mine">
     <maintenance type="money" amount="500"/>
     <construction skill="building" minskill="4">
       <requirement type="iron" quantity="1"/>
@@ -156,7 +156,7 @@
     </construction>
   </building>
 
-  <building name="lighthouse" capacity="1" maxcapacity="4">
+  <building name="lighthouse" maxcapacity="4">
     <maintenance type="money" amount="100"/>
     <construction skill="building" minskill="3">
       <requirement type="iron" quantity="1"/>

--- a/res/core/common/buildings.xml
+++ b/res/core/common/buildings.xml
@@ -129,7 +129,7 @@
 
   <building name="harbour" capacity="1" maxcapacity="25" maxsize="25" unique="yes">
     <maintenance type="money" amount="250"/>
-    <construction skill="building" minskill="3" reqsize="25" maxsize="25">
+    <construction skill="building" minskill="3" reqsize="25">
       <requirement type="log" quantity="125"/>
       <requirement type="stone" quantity="125"/>
       <requirement type="money" quantity="6250"/>

--- a/res/core/common/buildings.xml
+++ b/res/core/common/buildings.xml
@@ -7,14 +7,14 @@
   <building name="building" namechange="no" maxsize="1" nobuild="yes"/>
 
   <building name="blessedstonecircle" maxcapacity="3" maxsize="100" nobuild="yes" magic="yes" magres="60" magresbonus="30" auraregen="1.50">
-    <construction skill="building" minskill="2" reqsize="100" maxsize="100">
+    <construction skill="building" minskill="2" reqsize="100">
       <requirement type="log" quantity="500"/>
       <requirement type="stone" quantity="500"/>
     </construction>
   </building>
 
   <building name="stonecircle" maxsize="100">
-    <construction skill="building" minskill="2" reqsize="100" maxsize="100">
+    <construction skill="building" minskill="2" reqsize="100">
       <requirement type="log" quantity="500"/>
       <requirement type="stone" quantity="500"/>
     </construction>
@@ -33,7 +33,7 @@
   <building name="tunnel" capacity="1" maxsize="100">
     <maintenance type="stone" amount="2"/>
     <maintenance type="money" amount="100"/>
-    <construction skill="building" minskill="6" reqsize="100" maxsize="100">
+    <construction skill="building" minskill="6" reqsize="100">
       <requirement type="iron" quantity="100"/>
       <requirement type="log" quantity="500"/>
       <requirement type="stone" quantity="1000"/>
@@ -44,7 +44,7 @@
   <building name="caravan" capacity="1" maxsize="10">
     <maintenance type="horse" amount="2"/>
     <maintenance type="money" amount="3000"/>
-    <construction skill="building" minskill="2" reqsize="10" maxsize="10">
+    <construction skill="building" minskill="2" reqsize="10">
       <requirement type="iron" quantity="10"/>
       <requirement type="log" quantity="50"/>
       <requirement type="stone" quantity="10"/>
@@ -55,7 +55,7 @@
   <building name="dam" capacity="1" maxsize="50">
     <maintenance type="log" amount="3"/>
     <maintenance type="money" amount="1000"/>
-    <construction skill="building" minskill="4" reqsize="50" maxsize="50">
+    <construction skill="building" minskill="4" reqsize="50">
       <requirement type="iron" quantity="50"/>
       <requirement type="log" quantity="500"/>
       <requirement type="stone" quantity="250"/>
@@ -107,7 +107,7 @@
 
   <building name="magictower" maxcapacity="2" maxsize="50" magic="yes" magres="40" fumblebonus="10" auraregen="1.75">
     <maintenance type="money" amount="1000"/>
-    <construction skill="building" minskill="5" reqsize="50" maxsize="50">
+    <construction skill="building" minskill="5" reqsize="50">
       <requirement type="log" quantity="150"/>
       <requirement type="stone" quantity="250"/>
       <requirement type="mallorn" quantity="100"/>
@@ -119,7 +119,7 @@
 
   <building name="academy" maxcapacity="25" maxsize="25">
     <maintenance type="money" amount="1000"/>
-    <construction skill="building" minskill="3" reqsize="25" maxsize="25">
+    <construction skill="building" minskill="3" reqsize="25">
       <requirement type="log" quantity="125"/>
       <requirement type="stone" quantity="125"/>
       <requirement type="iron" quantity="25"/>

--- a/res/e3a/buildings.xml
+++ b/res/e3a/buildings.xml
@@ -3,7 +3,7 @@
 
   <xi:include href="config://default/buildings/castle-2.xml" />
 
-  <building name="watch" maxsize="10" capacity="1" fort="yes" taxes="200">
+  <building name="watch" maxsize="10" fort="yes" taxes="200">
     <construction skill="building" minskill="1" maxsize="5" name="scaffolding">
       <requirement type="log" quantity="1"/>
     </construction>
@@ -15,7 +15,7 @@
     </construction>
   </building>
 
-  <building name="market" capacity="1" maxsize="10">
+  <building name="market" maxsize="10">
     <maintenance type="money" amount="200"/>
     <construction skill="building" minskill="3">
       <requirement type="log" quantity="1"/>

--- a/res/eressea/buildings.xml
+++ b/res/eressea/buildings.xml
@@ -2,7 +2,7 @@
 <buildings xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="../buildings/castle.xml"/>
   <building name="temple" maxsize="50" maxcapacity="2" nobuild="yes" nodestroy="yes" unique="yes" auraregen="1.00" />
-  <building name="portal" maxsize="2" capacity="1" maxcapacity="2" nobuild="yes" nodestroy="yes" unique="yes" />
-  <building name="pavilion" maxsize="2" capacity="1" maxcapacity="2" nobuild="yes" nodestroy="yes" unique="yes" />
+  <building name="portal" maxsize="2" maxcapacity="2" nobuild="yes" nodestroy="yes" unique="yes" />
+  <building name="pavilion" maxsize="2" maxcapacity="2" nobuild="yes" nodestroy="yes" unique="yes" />
   <building name="artacademy" maxsize="100" nobuild="yes" nodestroy="yes" unique="yes"/>
 </buildings>

--- a/scripts/tests/e2/buildings.lua
+++ b/scripts/tests/e2/buildings.lua
@@ -52,22 +52,26 @@ function test_build_castle_stages()
     assert_equal(250, b.size)
 end
 
-function test_build_maxsize()
-    local r = region.create(0,0, "plain")
-    local f = faction.create("human")
-    local u = unit.create(f, r, 100)
-    local b = building.create(r, "harbour")
-    
-    b.size = 20
-    u:add_item("stone", 1000)
-    u:add_item("log", 1000)
-    u:add_item("money", 10000)
-
-    u:set_skill("building", 100)
+function test_build_harbour()
+-- try to reproduce mantis bug 2221
+    local r = region.create(0, 0, "plain")
+    local f = faction.create("human", "harbour@eressea.de", "de")
+    local u = unit.create(f, r)
+    size = 30
+    u.number = 20
+    u:set_skill("building", 3)
+    u:add_item("money", size*250)
+    u:add_item("stone", size*5)
+    u:add_item("log", size*5)
     u:clear_orders()
-    u:add_order("MACHE BURG " .. itoa36(b.id))
+    u:add_order("MACHE HAFEN")
     process_orders()
-    assert_equal(25, b.size) -- build no more than max
+    assert_not_nil(u.building)
+    assert_equal("harbour", u.building.type)
+    assert_equal(20, u.building.size)
     process_orders()
-    assert_equal(25, b.size) -- stop at max
+    assert_equal(25, u.building.size)
+    process_orders()
+    assert_equal(25, u.building.size)
 end
+

--- a/scripts/tests/e2/buildings.lua
+++ b/scripts/tests/e2/buildings.lua
@@ -51,3 +51,23 @@ function test_build_castle_stages()
     process_orders()
     assert_equal(250, b.size)
 end
+
+function test_build_maxsize()
+    local r = region.create(0,0, "plain")
+    local f = faction.create("human")
+    local u = unit.create(f, r, 100)
+    local b = building.create(r, "harbour")
+    
+    b.size = 20
+    u:add_item("stone", 1000)
+    u:add_item("log", 1000)
+    u:add_item("money", 10000)
+
+    u:set_skill("building", 100)
+    u:clear_orders()
+    u:add_order("MACHE BURG " .. itoa36(b.id))
+    process_orders()
+    assert_equal(25, b.size) -- build no more than max
+    process_orders()
+    assert_equal(25, b.size) -- stop at max
+end

--- a/scripts/tests/e2/e2features.lua
+++ b/scripts/tests/e2/e2features.lua
@@ -62,29 +62,6 @@ function test_dwarf_bonus()
     assert_equal(70, r:get_resource("iron"))
 end
 
-function test_build_harbour()
--- try to reproduce mantis bug 2221
-    local r = region.create(0, 0, "plain")
-    local f = faction.create("human", "harbour@eressea.de", "de")
-    local u = unit.create(f, r)
-    size = 30
-    u.number = 20
-    u:set_skill("building", 3)
-    u:add_item("money", size*250)
-    u:add_item("stone", size*5)
-    u:add_item("log", size*5)
-    u:clear_orders()
-    u:add_order("MACHE HAFEN")
-    process_orders()
-    assert_not_nil(u.building)
-    assert_equal("harbour", u.building.type)
-    assert_equal(20, u.building.size)
-    process_orders()
-    assert_equal(25, u.building.size)
-    process_orders()
-    assert_equal(25, u.building.size)
-end
-
 local function one_unit(r, f)
   local u = unit.create(f, r, 1)
   u:add_item("money", u.number * 100)

--- a/src/kernel/build.c
+++ b/src/kernel/build.c
@@ -717,8 +717,9 @@ build_building(unit * u, const building_type * btype, int id, int want, order * 
         b = u->building;
     }
 
-    if (b)
+    if (b) {
         btype = b->type;
+    }
 
     if (fval(btype, BTF_UNIQUE) && buildingtype_exists(r, btype, false)) {
         /* only one of these per region */

--- a/src/kernel/building.c
+++ b/src/kernel/building.c
@@ -310,6 +310,7 @@ static const int watch_bonus[3] = { 0, 1, 2 };
 
 int building_protection(const building_type * btype, int stage)
 {
+    assert(btype->flags & BTF_FORTIFICATION);
     if (btype->maxsize < 0) {
         return castle_bonus[MIN(stage, 5)];
     }

--- a/src/kernel/building.test.c
+++ b/src/kernel/building.test.c
@@ -570,11 +570,32 @@ static void test_buildingtype(CuTest *tc) {
     test_cleanup();
 }
 
+static void test_buildingcapacity(CuTest *tc) {
+    building *b;
+    building_type *btype;
+    test_setup();
+    btype = test_create_buildingtype("lighthouse");
+    btype->capacity = 1;
+    btype->maxcapacity = 4;
+    b = test_create_building(test_create_region(0, 0, NULL), btype);
+
+    b->size = 1;
+    CuAssertIntEquals(tc, b->size*btype->capacity, buildingcapacity(b));
+    b->size = 5;
+    CuAssertIntEquals(tc, btype->maxcapacity, buildingcapacity(b));
+
+    btype->capacity = -1;
+    CuAssertTrue(tc, building_finished(b));
+    CuAssertIntEquals(tc, btype->maxcapacity, buildingcapacity(b));
+    test_cleanup();
+}
+
 CuSuite *get_building_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, test_buildingtype);
     SUITE_ADD_TEST(suite, test_largestbuilding);
+    SUITE_ADD_TEST(suite, test_buildingcapacity);
     SUITE_ADD_TEST(suite, test_cmp_castle_size);
     SUITE_ADD_TEST(suite, test_cmp_taxes);
     SUITE_ADD_TEST(suite, test_cmp_wage);

--- a/src/reports.c
+++ b/src/reports.c
@@ -1405,10 +1405,12 @@ void prepare_report(report_context *ctx, faction *f)
     region *r;
     static int config;
     static bool rule_region_owners;
+    static bool rule_lighthouse_units;
     const struct building_type *bt_lighthouse = bt_find("lighthouse");
 
     if (bt_lighthouse && config_changed(&config)) {
         rule_region_owners = config_token("rules.region_owner_pay_building", bt_lighthouse->_name);
+        rule_lighthouse_units = config_get_int("rules.lighthouse.unit_capacity", 0) != 0;
     }
 
     if (f->age <= 2) {
@@ -1471,7 +1473,12 @@ void prepare_report(report_context *ctx, faction *f)
                         c = buildingcapacity(b);
                         br = 0;
                     }
-                    c -= u->number;
+                    if (rule_lighthouse_units) {
+                        --c;
+                    }
+                    else {
+                        c -= u->number;
+                    }
                     if (u->faction == f && c >= 0) {
                         /* unit is one of ours, and inside the current lighthouse */
                         if (br == 0) {

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -496,7 +496,7 @@ void test_prepare_lighthouse_capacity(CuTest *tc) {
     CuAssertIntEquals(tc, seen_neighbour, r2->seen.mode);
     finish_reports(&ctx);
 
-    // lighthouse capacity is # of units, not people:
+    /* lighthouse capacity is # of units, not people: */
     config_set_int("rules.lighthouse.unit_capacity", 1);
     prepare_report(&ctx, u2->faction);
     CuAssertPtrEquals(tc, r1, ctx.first);

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -496,6 +496,15 @@ void test_prepare_lighthouse_capacity(CuTest *tc) {
     CuAssertIntEquals(tc, seen_neighbour, r2->seen.mode);
     finish_reports(&ctx);
 
+    // lighthouse capacity is # of units, not people:
+    config_set_int("rules.lighthouse.unit_capacity", 1);
+    prepare_report(&ctx, u2->faction);
+    CuAssertPtrEquals(tc, r1, ctx.first);
+    CuAssertPtrEquals(tc, 0, ctx.last);
+    CuAssertIntEquals(tc, seen_unit, r1->seen.mode);
+    CuAssertIntEquals(tc, seen_lighthouse, r2->seen.mode);
+    finish_reports(&ctx);
+
     test_cleanup();
 }
 


### PR DESCRIPTION
Featurewunsch aus https://bugs.eressea.de/view.php?id=2337

Die geringe Kapazität von Leuchttürmen verlangte bisher, dass man seine Einheiten im Turm aufsplittet und sorgfältig platziert, so dass möglichst vier 1-Personen Einheiten von vier verschiedenen Parteien drin stehen, um die maximale Ausbeute zu bekommen.

Diese Regel ist jetzt gelockert, so dass die ersten 4 *Einheiten*, nicht *Personen* die Sicht aus dem Leuchtturmes genießen können.
