### PR TITLE
remove irace assumptions

### DIFF
--- a/src/creport.c
+++ b/src/creport.c
@@ -853,8 +853,6 @@ void cr_output_unit(stream *out, const region * r, const faction * f,
         stream_printf(out, "\"%s\";Typ\n",
             translate(zRace, LOC(f->locale, zRace)));
         if (u->faction == f && irace != u_race(u)) {
-            assert(skill_enabled(SK_STEALTH)
-                || !"we're resetting this on load, so.. ircase should never be used");
             zRace = rc_name_s(u_race(u), NAME_PLURAL);
             stream_printf(out, "\"%s\";wahrerTyp\n",
                 translate(zRace, LOC(f->locale, zRace)));

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -509,7 +509,7 @@ unit *read_unit(gamedata *data)
     u_setrace(u, rc);
 
     READ_TOK(data->store, rname, sizeof(rname));
-    if (rname[0] && skill_enabled(SK_STEALTH))
+    if (rname[0])
         u->irace = rc_find(rname);
     else
         u->irace = NULL;

--- a/src/kernel/save.test.c
+++ b/src/kernel/save.test.c
@@ -1,5 +1,6 @@
 #include <platform.h>
 #include <kernel/config.h>
+#include <kernel/race.h>
 #include <util/attrib.h>
 #include <util/gamedata.h>
 #include <attributes/key.h>
@@ -51,6 +52,7 @@ static void test_readwrite_unit(CuTest * tc)
     struct unit *u;
     struct region *r;
     struct faction *f;
+    struct race *irace;
     int fno;
 
     test_setup();
@@ -60,6 +62,12 @@ static void test_readwrite_unit(CuTest * tc)
     u = test_create_unit(f, r);
     unit_setname(u, "  Hodor  ");
     CuAssertStrEquals(tc, "  Hodor  ", u->_name);
+    enable_skill(SK_STEALTH, false);
+    irace = test_create_race("halfling");
+    CuAssertTrue(tc, playerrace(irace));
+    u->irace = irace;
+    CuAssertTrue(tc, irace == u_irace(u));
+    
     mstream_init(&data.strm);
     gamedata_init(&data, &store, RELEASE_VERSION);
     write_unit(&data, u);
@@ -74,6 +82,7 @@ static void test_readwrite_unit(CuTest * tc)
     CuAssertPtrNotNull(tc, u);
     CuAssertPtrEquals(tc, f, u->faction);
     CuAssertStrEquals(tc, "Hodor", u->_name);
+    CuAssertTrue(tc, irace == u_irace(u));
     CuAssertPtrEquals(tc, 0, u->region);
 
     mstream_done(&data.strm);


### PR DESCRIPTION
Fixes bug 2383. Factions may have illusionary races without stealth. Includes Enno's fix.