### PR TITLE
https://bugs.eressea.de/view.php?id=2712

### DIFF
--- a/scripts/reports.lua
+++ b/scripts/reports.lua
@@ -1,4 +1,7 @@
 dofile('config.lua')
 eressea.read_game(get_turn() .. '.dat')
 init_reports()
-write_reports()
+-- do not use write_reports, since it will change passwords
+for f in factions() do
+    write_report(f)
+end

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -378,7 +378,7 @@ static int tolua_write_report(lua_State * L)
 {
     faction *f = (faction *)tolua_tousertype(L, 1, 0);
     if (f) {
-        int result = write_reports(f);
+        int result = write_reports(f, NULL);
         lua_pushinteger(L, result);
     }
     else {

--- a/src/reports.h
+++ b/src/reports.h
@@ -46,7 +46,7 @@ extern "C" {
         const struct unit *u, unsigned int indent, seen_mode mode);
 
     int reports(void);
-    int write_reports(struct faction *f);
+    int write_reports(struct faction *f, const char *password);
     int init_reports(void);
     void reorder_units(struct region * r);
 

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -960,14 +960,18 @@ static void test_reports_genpassword(CuTest *tc) {
     CuAssertIntEquals(tc, 0, f->lastorders);
     CuAssertIntEquals(tc, 0, f->password_id);
     f->options = 0;
-    write_reports(f);
+    /* writing the report does not change the password */
+    write_reports(f, NULL);
+    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "changepasswd"));
+    /* but the main reporting function does */
+    reports();
     CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "changepasswd"));
     CuAssertTrue(tc, f->password_id != 0);
     test_clear_messagelist(&f->msgs);
     f->lastorders = 1;
     f->age = 2;
     pwid = f->password_id;
-    write_reports(f);
+    reports();
     CuAssertIntEquals(tc, pwid, f->password_id);
     CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "changepasswd"));
     test_teardown();


### PR DESCRIPTION
Make the reports.lua script not break passwords of
 new players.