### PR TITLE
fix for flee spell

### DIFF
--- a/src/spells.c
+++ b/src/spells.c
@@ -6195,21 +6195,21 @@ static int sp_flee(castorder *co) {
     if (co->force <= 0) {
         return 0;
     }
-    return flee_spell(co, 4);
+    return flee_spell(co, 4, false);
 }
 
 static int sp_song_of_fear(castorder *co) {
     if (co->force <= 0) {
         return 0;
     }
-    return flee_spell(co, 3);
+    return flee_spell(co, 3, true);
 }
 
 static int sp_aura_of_fear(castorder *co) {
     if (co->force <= 0) {
         return 0;
     }
-    return flee_spell(co, 5);
+    return flee_spell(co, 5, false);
 }
 
 static int sp_armor_shield(struct castorder * co) {

--- a/src/spells/combatspells.c
+++ b/src/spells/combatspells.c
@@ -861,7 +861,7 @@ static bool select_afraid(const side *vs, const fighter *fig, void *cbdata)
 
 /* Gesang der Furcht (Kampfzauber) */
 /* Panik (Praekampfzauber) */
-int flee_spell(struct castorder * co, int strength)
+int flee_spell(struct castorder * co, int strength, bool wounded)
 {
     fighter * fi = co->magician.fig;
     int level = co->level;
@@ -882,7 +882,7 @@ int flee_spell(struct castorder * co, int strength)
         return 0;
     }
 
-    fgs = select_fighters(b, fi->side, FS_ENEMY, select_afraid, NULL);
+    fgs = select_fighters(b, fi->side, FS_ENEMY, wounded?select_afraid:select_alive, NULL);
     scramble_fighters(fgs);
 
     for (qi = 0, ql = fgs; force > 0 && ql; selist_advance(&ql, &qi, 1)) {
@@ -895,7 +895,7 @@ int flee_spell(struct castorder * co, int strength)
                 ++panik;
             }
             else if (!(df->person[n].flags & FL_COURAGE)
-                || !(u_race(df->unit)->flags & RCF_UNDEAD)) {
+                && !(u_race(df->unit)->flags & RCF_UNDEAD)) {
                 if (!is_magic_resistant(mage, df->unit, 0)) {
                     df->person[n].flags |= FL_PANICED;
                     ++panik;

--- a/src/spells/combatspells.h
+++ b/src/spells/combatspells.h
@@ -1,6 +1,8 @@
 #ifndef H_GC_COMBATSPELLS
 #define H_GC_COMBATSPELLS
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,7 +38,7 @@ extern "C" {
     int sp_undeadhero(struct castorder * co);
     int sp_immolation(struct castorder * co);
 
-    int flee_spell(struct castorder * co, int strength);
+    int flee_spell(struct castorder * co, int strength, bool wounded);
     int damage_spell(struct castorder * co, int dmg, int strength);
     int armor_spell(struct castorder * co, int per_level, int time_multi);
 


### PR DESCRIPTION
2 Probleme hier: 
1. kleiner Logikfehler mit RCF_UNDEAD (siehe Anmerkung)
2. Den Kampfzauber Gesang der Furcht (mit dem war alles in Ordnung) und den Präkampfzauber Grauen der Schlacht. Der hatte nie eine Wirkung. Grund war, das select_fighters mit dem Filter select_afraid aufgerufen wird, was nur Einheiten auswählt, die schon Verluste hatten. Bei einem Präkampfzauber kann das aber praktisch nie der Fall sein. Deshalb muss der alle lebenden Einheiten auswählen.

Nebenbei gesagt ist select_afraid vielleicht schlechtes Design, weil es große Einheiten bevorzugt auswählt.