### PR TITLE
more verbosity for soulless demons

### DIFF
--- a/res/core/messages.xml
+++ b/res/core/messages.xml
@@ -1087,6 +1087,13 @@
     </type>
   </message>
 
+  <message name="reanimate_no_soul" section="magic">
+    <type>
+      <arg name="mage" type="unit"/>
+      <arg name="amount" type="int"/>
+    </type>
+  </message>
+
   <message name="chaosgate_effect_1" section="magic">
     <type>
       <arg name="mage" type="unit"/>

--- a/res/translations/messages.de.po
+++ b/res/translations/messages.de.po
@@ -2801,3 +2801,5 @@ msgstr "\"$unit($unit) in $region($region): $int($number) $race($race,$number) $
 msgid "sp_eternizewall_effect"
 msgstr "\"Mit einem Ritual bindet $unit($mage) die magischen Kräfte der Erde von $region($region) in die Mauern von $building($building).\""
 
+msgid "reanimate_no_soul"
+msgstr "$int($amount) Dämonen konnten nicht wiederbelebt werden, da sie keine Seele haben.\"

--- a/res/translations/messages.en.po
+++ b/res/translations/messages.en.po
@@ -2801,3 +2801,5 @@ msgstr "\"$unit($unit) in $region($region): $int($number) $race($race,$number) t
 msgid "sp_eternizewall_effect"
 msgstr "\"$unit($mage) performs a ritual that binds the magical forces of $region($region) into the walls of $building($building).\""
 
+msgid "reanimate_no_soul"
+msgstr "$int($amount) demons would not rise from the dead because they don't have a soul.\"


### PR DESCRIPTION
Der Zauber Wiederbelebung funktioniert nicht bei Dämonen. Allerdings gab es dazu keine Rückmeldung und aus der Zauberbeschreibung geht es nicht hervor.

Davon abgesehen halte ich das auch für einen Designfehler: Dämonen sind eine Spielerrasse und ich sehe nicht, warum die an der Stelle noch weiter bestraft werden müssen. Man sollte den Check besser ganz streichen.