### PR TITLE
FFL_DEFENDER is deprecated and interfers with dreams

### DIFF
--- a/scripts/tests/common.lua
+++ b/scripts/tests/common.lua
@@ -66,7 +66,7 @@ function test_flags()
     local f = create_faction('halfling')
     local u = unit.create(f, r, 1)
     local no = itoa36(f.id)
-    local flags = 50332672
+    local flags = 50331648
     f.flags = flags
 
     eressea.write_game("test.dat")

--- a/src/kernel/ally.c
+++ b/src/kernel/ally.c
@@ -326,7 +326,6 @@ int alliedunit(const unit * u, const faction * f2, int mask)
 {
     assert(u);
     assert(f2);
-    assert(u->region);            /* the unit should be in a region, but it's possible that u->number==0 (TEMP units) */
     if (u->faction == f2) {
         return mask;
     }
@@ -335,17 +334,6 @@ int alliedunit(const unit * u, const faction * f2, int mask)
     }
     if (u->faction != NULL && f2 != NULL) {
         group *g;
-
-        if (mask & HELP_FIGHT) {
-            if ((u->flags & UFL_DEFENDER) || (u->faction->flags & FFL_DEFENDER)) {
-                faction *owner = region_get_owner(u->region);
-                /* helps the owner of the region */
-                if (owner == f2) {
-                    return HELP_FIGHT;
-                }
-            }
-        }
-
         g = get_group(u);
         if (g) {
             return alliedgroup(u->faction, f2, g, mask);
@@ -354,4 +342,3 @@ int alliedunit(const unit * u, const faction * f2, int mask)
     }
     return 0;
 }
-

--- a/src/kernel/faction.h
+++ b/src/kernel/faction.h
@@ -27,15 +27,14 @@ extern "C" {
 #define FFL_PWMSG         (1<<2)  /* received a "new password" message */
 #define FFL_QUIT          (1<<3)
 #define FFL_CURSED        (1<<4)  /* you're going to have a bad time */
-#define FFL_DEFENDER      (1<<10)
 #define FFL_SELECT        (1<<22) /* ehemals f->dh, u->dh, r->dh, etc... */
-#define FFL_MARK          (1<<23) /* fuer markierende algorithmen, die das 
+#define FFL_MARK          (1<<23) /* fuer markierende algorithmen, die das
                                    * hinterher auch wieder loeschen muessen!
                                    * (FFL_SELECT muss man vorher initialisieren,
                                    * FL_MARK hinterher loeschen) */
 #define FFL_NOIDLEOUT     (1<<24) /* Partei stirbt nicht an NMRs */
 #define FFL_NPC           (1<<25) /* eine Partei mit Monstern */
-#define FFL_SAVEMASK (FFL_DEFENDER|FFL_NPC|FFL_NOIDLEOUT|FFL_CURSED)
+#define FFL_SAVEMASK (FFL_NPC|FFL_NOIDLEOUT|FFL_CURSED)
 
     typedef struct origin {
         struct origin *next;

--- a/src/kernel/unit.h
+++ b/src/kernel/unit.h
@@ -28,7 +28,6 @@ extern "C" {
 #define UFL_HERO          (1<<7)
 #define UFL_MOVED         (1<<8)
 #define UFL_NOTMOVING     (1<<9)        /* Die Einheit kann sich wg. langen Kampfes nicht bewegen */
-#define UFL_DEFENDER      (1<<10)
 #define UFL_HUNGER        (1<<11)       /* kann im Folgemonat keinen langen Befehl ausser ARBEITE ausfuehren */
 #define UFL_TARGET        (1<<13)       /* speedup: hat ein target, siehe attribut */
 #define UFL_WERE          (1<<14)
@@ -52,7 +51,7 @@ extern "C" {
 #define UFL_GROUP         (1<<28)
 
     /* Flags, die gespeichert werden sollen: */
-#define UFL_SAVEMASK (UFL_DEFENDER|UFL_MOVED|UFL_NOAID|UFL_ANON_FACTION|UFL_LOCKED|UFL_HUNGER|UFL_TAKEALL|UFL_GUARD|UFL_STEALTH|UFL_GROUP|UFL_HERO)
+#define UFL_SAVEMASK (UFL_MOVED|UFL_NOAID|UFL_ANON_FACTION|UFL_LOCKED|UFL_HUNGER|UFL_TAKEALL|UFL_GUARD|UFL_STEALTH|UFL_GROUP|UFL_HERO)
 
 #define UNIT_MAXSIZE 128 * 1024
     extern int maxheroes(const struct faction *f);

--- a/src/spy.test.c
+++ b/src/spy.test.c
@@ -200,17 +200,17 @@ static void test_setstealth_cmd(CuTest *tc) {
     test_setup();
     u = test_create_unit(test_create_faction(), test_create_plain(0, 0));
     lang = u->faction->locale;
-    u->flags = UFL_ANON_FACTION | UFL_DEFENDER;
+    u->flags = UFL_ANON_FACTION | UFL_MOVED;
     u->thisorder = create_order(K_SETSTEALTH, lang, "%s %s",
         LOC(lang, parameters[P_FACTION]),
         LOC(lang, parameters[P_NOT]));
     setstealth_cmd(u, u->thisorder);
-    CuAssertIntEquals(tc, UFL_DEFENDER, u->flags);
+    CuAssertIntEquals(tc, UFL_MOVED, u->flags);
     free_order(u->thisorder);
     u->thisorder = create_order(K_SETSTEALTH, lang, "%s",
         LOC(lang, parameters[P_FACTION]));
     setstealth_cmd(u, u->thisorder);
-    CuAssertIntEquals(tc, UFL_DEFENDER | UFL_ANON_FACTION, u->flags);
+    CuAssertIntEquals(tc, UFL_MOVED | UFL_ANON_FACTION, u->flags);
     test_teardown();
 }
 


### PR DESCRIPTION
Die Flags FFL_DEFENDER und UFL_DEFENDER scheinen gar keine Funktion zu haben. Dadurch vereinfacht sich die Behandlung der guten Träume.

Die Flags wurden in commit 319abf6c5d12d5b3253a83b0e5e6c9a3dc13cffe ohne ersichtlichen Grund eingeführt. Irgendein verschwundener Zauber?