### PR TITLE
report newbie immuniy clearly

### DIFF
--- a/res/core/messages.xml
+++ b/res/core/messages.xml
@@ -5480,6 +5480,8 @@
       <arg name="turns" type="int"/>
     </type>
   </message>
+  <message name="newbieimmunityending" section="nr" />
+  <message name="newbieimmunityended" section="nr" />
   <message name="alliance::kickedout" section="events">
     <type>
       <arg name="votes" type="int"/>

--- a/res/translations/messages.de.po
+++ b/res/translations/messages.de.po
@@ -2649,7 +2649,13 @@ msgid "error201"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Rasse und Zieleinheit wurden vergessen.\""
 
 msgid "newbieimmunity"
-msgstr "\"Deine Partei ist noch $int($turns) Wochen immun gegen Angriffe.\""
+msgstr "\"Deine Partei ist noch die nächsten $int($turns) Wochen immun gegen Angriffe.\""
+
+msgid "newbieimmunityending"
+msgstr "\"Deine Partei ist nur noch in der kommenden Woche immun gegen Angriffe.\""
+
+msgid "newbieimmunityended"
+msgstr "\"Deine Partei ist nun nicht mehr immun gegen Angriffe.\""
 
 msgid "curseinfo::auraboost_0"
 msgstr "\"$unit($unit) fühlt sich von starken magischen Energien durchströmt. ($int36($id))\""

--- a/res/translations/messages.en.po
+++ b/res/translations/messages.en.po
@@ -2649,7 +2649,13 @@ msgid "error201"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Race and target unit have not been supplied.\""
 
 msgid "newbieimmunity"
-msgstr "\"Your faction is immune against assaults for $int($turns) more weeks.\""
+msgstr "\"Your faction will be immune against assaults for the next $int($turns) weeks.\""
+
+msgid "newbieimmunityending"
+msgstr "\"Your faction will be immune against assaults only one more week.\""
+
+msgid "newbieimmunityended"
+msgstr "\"Your faction will no longer be immune against assaults.\""
 
 msgid "curseinfo::auraboost_0"
 msgstr "\"Powerful magical energies are pulsing through $unit($unit). ($int36($id))\""

--- a/src/reports.c
+++ b/src/reports.c
@@ -1433,9 +1433,16 @@ static void cb_add_seen(region *r, unit *u, void *cbdata) {
 void report_warnings(faction *f, int now)
 {
     if (f->age < NewbieImmunity()) {
-        ADDMSG(&f->msgs, msg_message("newbieimmunity", "turns",
-            NewbieImmunity() - f->age));
-    }
+        assert(IsImmune(f));
+        if (f->age + 2 < NewbieImmunity()) {
+            ADDMSG(&f->msgs, msg_message("newbieimmunity", "turns",
+                NewbieImmunity() - f->age - 1));
+        } else if (f->age +1 < NewbieImmunity()) {
+            ADDMSG(&f->msgs, msg_message("newbieimmunityending", ""));
+        } else {
+            ADDMSG(&f->msgs, msg_message("newbieimmunityended", ""));
+        }
+    } /* else assert(!IsImmune(f)); */
 
     if (f->race == get_race(RC_INSECT)) {
         season_t season = calendar_season(now + 1);

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -835,14 +835,30 @@ static void test_newbie_warning(CuTest *tc) {
     f = test_create_faction();
     config_set_int("NewbieImmunity", 3);
 
-    f->age = 2;
+    f->age = 0;
     report_warnings(f, 0);
     CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "newbieimmunity"));
+    CuAssertIntEquals(tc, true, IsImmune(f));
+    test_clear_messages(f);
+
+    f->age = 1;
+    report_warnings(f, 0);
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "newbieimmunityending"));
+    CuAssertIntEquals(tc, true, IsImmune(f));
+    test_clear_messages(f);
+
+    f->age = 2;
+    report_warnings(f, 0);
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "newbieimmunityended"));
+    CuAssertIntEquals(tc, true, IsImmune(f));
     test_clear_messages(f);
 
     f->age = 3;
     report_warnings(f, 0);
+    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "newbieimmunityended"));
+    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "newbieimmunityending"));
     CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "newbieimmunity"));
+    CuAssertIntEquals(tc, false, IsImmune(f));
     test_clear_messages(f);
 
     test_teardown();


### PR DESCRIPTION
Bisher wurde "Deine Partei ist noch 1 Wochen immun" gemeldet, wenn die Partei in der nächsten Auswertung, für die der Benutzer befehle schickt, nicht mehr immun ist. Ich habe x jetzt um eine Woche reduziert und für die Grenzfälle eigene Nachrichten.

Der Config-Parameter "NewbieImmunity" ist eventuell nicht intuitiv definiert, daran habe ich aber nichts geändert.