### PR TITLE
Name cmd

### DIFF
--- a/res/core/messages.xml
+++ b/res/core/messages.xml
@@ -2272,47 +2272,50 @@
   </message>
   <message name="renamed_faction_notseen" section="events">
     <type>
+      <arg name="renamed" type="faction"/>
+      <arg name="region" type="region"/>
   </type>
   </message>
   <message name="renamed_faction_seen" section="events">
     <type>
-      <arg name="unit" type="unit"/>
+      <arg name="renamed" type="faction"/>
       <arg name="region" type="region"/>
+      <arg name="renamer" type="unit"/>
     </type>
   </message>
   <message name="renamed_building_notseen" section="events">
     <type>
-      <arg name="building" type="building"/>
+      <arg name="renamed" type="building"/>
       <arg name="region" type="region"/>
     </type>
   </message>
   <message name="renamed_building_seen" section="events">
     <type>
-      <arg name="building" type="building"/>
+      <arg name="renamed" type="building"/>
       <arg name="region" type="region"/>
       <arg name="renamer" type="unit"/>
     </type>
   </message>
   <message name="renamed_ship_notseen" section="events">
     <type>
-      <arg name="ship" type="ship"/>
+      <arg name="renamed" type="ship"/>
       <arg name="region" type="region"/>
     </type>
   </message>
   <message name="renamed_ship_seen" section="events">
     <type>
-      <arg name="ship" type="ship"/>
+      <arg name="renamed" type="ship"/>
       <arg name="region" type="region"/>
       <arg name="renamer" type="unit"/>
     </type>
   </message>
-  <message name="renamed_notseen" section="events">
+  <message name="renamed_unit_notseen" section="events">
     <type>
       <arg name="renamed" type="unit"/>
       <arg name="region" type="region"/>
     </type>
   </message>
-  <message name="renamed_seen" section="events">
+  <message name="renamed_unit_seen" section="events">
     <type>
       <arg name="renamed" type="unit"/>
       <arg name="region" type="region"/>
@@ -3263,28 +3266,28 @@
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error247" section="errors">
+  <message name="faction_renamed" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error246" section="errors">
+  <message name="building_renamed" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error245" section="errors">
+  <message name="ship_renamed" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error244" section="errors">
+  <message name="unit_renamed" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -4115,7 +4118,7 @@
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error147" section="errors">
+  <message name="not_region_owner" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -4129,7 +4132,7 @@
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error145" section="errors">
+  <message name="not_in_building" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -4137,6 +4140,13 @@
     </type>
   </message>
   <message name="error144" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
+    </type>
+  </message>
+  <message name="not_in_ship" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -4346,14 +4356,14 @@
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error110" section="errors">
+  <message name="display_what" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error109" section="errors">
+  <message name="name_what" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -4704,7 +4714,7 @@
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error66" section="errors">
+  <message name="faction_not_found" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -5114,6 +5124,13 @@
       <arg name="command" type="order"/>
     </type>
   </message>
+  <message name="ship_not_found" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
+    </type>
+  </message>
   <message name="error19" section="errors">
     <type>
       <arg name="unit" type="unit"/>
@@ -5178,7 +5195,14 @@
       <arg name="command" type="order"/>
     </type>
   </message>
-  <message name="error1222" section="errors">
+  <message name="not_ship_owner" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
+    </type>
+  </message>
+  <message name="not_building_owner" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -5221,6 +5245,13 @@
     </type>
   </message>
   <message name="error6" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
+    </type>
+  </message>
+  <message name="building_not_found" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>
@@ -6391,6 +6422,38 @@
       <arg name="number" type="int"/>
       <arg name="target" type="region"/>
       <arg name="growl" type="string"/>
+    </type>
+  </message>
+
+  <message name="foreign_not_allowed" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
+    </type>
+  </message>
+
+  <message name="not_in_group" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
+    </type>
+  </message>
+
+  <message name="not_in_alliance" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
+    </type>
+  </message>
+
+  <message name="not_alliance_owner" section="errors">
+    <type>
+      <arg name="unit" type="unit"/>
+      <arg name="region" type="region"/>
+      <arg name="command" type="order"/>
     </type>
   </message>
 

--- a/res/translations/messages.de.po
+++ b/res/translations/messages.de.po
@@ -207,7 +207,7 @@ msgid "curseinfo::Feuerwand"
 msgstr "Eine Feuerwand blockiert die Ein- und Ausreise. ($int36($id))"
 
 msgid "renamed_building_notseen"
-msgstr "\"$building($building) in $region($region) bekommt einen Spitznamen.\""
+msgstr "\"$building($renamed) in $region($region) bekommt einen Spitznamen.\""
 
 msgid "heroes_race"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - $race($race,0) können keine Helden erwählen.\""
@@ -303,6 +303,9 @@ msgid "itemcloak"
 msgstr "\"$unit($mage) legt einen Schleier um die Ausrüstung von $unit.dative($target).\""
 
 msgid "error5"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Gebäude gehört uns nicht.\""
+
+msgid "not_building_owner"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Gebäude gehört uns nicht.\""
 
 msgid "para_tactics_lost"
@@ -417,7 +420,7 @@ msgid "dumbeffect"
 msgstr "\"$unit($unit) vergisst durch Dumpfbackenbrot $int($weeks) Wochen des Talentes $skill($skill).\""
 
 msgid "renamed_ship_seen"
-msgstr "\"Die $ship($ship) in $region($region) bekommt von $unit.dative($renamer) einen Spitznamen.\""
+msgstr "\"Die $ship($renamed) in $region($region) bekommt von $unit.dative($renamer) einen Spitznamen.\""
 
 msgid "error126"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - So etwas kann man nicht verkaufen.\""
@@ -521,13 +524,13 @@ msgstr "\"Eine gewaltige Flutwelle verschlingt $unit($unit) in $region($region).
 msgid "error14"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Schiff ist auf hoher See.\""
 
-msgid "renamed_notseen"
+msgid "renamed_unit_notseen"
 msgstr "\"$unit($renamed) in $region($region) bekommt einen Spitznamen.\""
 
 msgid "curseinfo::goodmagicresistancezone"
 msgstr "\"Die natürliche Widerstandskraft gegen Verzauberung bestimmter Einheiten in dieser Region wurde gestärkt. ($int36($id))\""
 
-msgid "error66"
+msgid "faction_not_found"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Partei wurde nicht gefunden.\""
 
 msgid "error88"
@@ -575,7 +578,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Region ist 
 msgid "para_lineup_battle"
 msgstr "\"Einheiten vor der $int($turn). Runde:\""
 
-msgid "error245"
+msgid "ship_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Schiff hat schon einen Namen.\""
 
 msgid "sp_chaosrow_effect_0"
@@ -710,6 +713,9 @@ msgstr "\"$unit($unit) nimmt Schaden durch den Giftelementar in $region($region)
 msgid "error144"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit ist auf keinem Schiff.\""
 
+msgid "not_in_ship"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit ist auf keinem Schiff.\""
+
 msgid "magicboost_effect"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Sphären des Chaos geben dem Magier einen Teil ihrer Kraft.\""
 
@@ -782,7 +788,7 @@ msgstr "\"$unit($unit) bekommt von einer Schlange einen Apfel angeboten. ($int36
 msgid "skill_needed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Dazu braucht man das Talent $skill($skill).\""
 
-msgid "renamed_seen"
+msgid "renamed_unit_seen"
 msgstr "\"$unit($renamed) in $region($region) bekommt von $unit.dative($renamer) einen Spitznamen.\""
 
 msgid "analyse_unit_nospell"
@@ -848,7 +854,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit mu�
 msgid "error_herorecruit"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Helden können nicht rekrutieren.\""
 
-msgid "error109"
+msgid "name_what"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Man muß angeben, ob eine Burg, ein Schiff, eine Einheit, eine Region oder eine Partei benannt werden soll.\""
 
 msgid "msg_event"
@@ -872,7 +878,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Leere Einheiten
 msgid "curseinfo::sparkle_7"
 msgstr "\"Die Frauen des nahegelegenen Dorfes bewundern $unit($unit) verstohlen. ($int36($id))\""
 
-msgid "error110"
+msgid "display_what"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Man muß angeben, ob eine Burg, ein Schiff, eine Region oder eine Einheit beschrieben werden soll.\""
 
 msgid "curseinfo::sparkle_18"
@@ -1149,7 +1155,7 @@ msgid "plant_skills"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Man benötigt mindestens $int($minskill) $skill($skill), um $resource($product,0) zu pflanzen.\""
 
 msgid "renamed_ship_notseen"
-msgstr "\"Die $ship($ship) in $region($region) bekommt einen Spitznamen.\""
+msgstr "\"Die $ship($renamed) in $region($region) bekommt einen Spitznamen.\""
 
 msgid "error123"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - So etwas hat die Einheit nicht.\""
@@ -1268,7 +1274,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Eine Einheit ka
 msgid "cast_rally_effect"
 msgstr "\"$unit($mage) besänftigt den Bauernaufstand in $region($region).\""
 
-msgid "error246"
+msgid "building_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Gebäude hat schon einen Namen.\""
 
 msgid "stealaura_fail"
@@ -1436,7 +1442,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Wohin soll die 
 msgid "curseinfo::building_unknown"
 msgstr "\"Ein unbekannter Zauber liegt auf dem Gebäude. ($int36($id))\""
 
-msgid "error145"
+msgid "not_in_building"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit ist in keiner Burg.\""
 
 msgid "piratenovictim"
@@ -1509,7 +1515,7 @@ msgid "battle_row"
 msgstr "\"... in der $int($row). Kampflinie:\""
 
 msgid "renamed_faction_seen"
-msgstr "\"Die Partei bekommt von $unit.dative($unit) in $region($region) einen Spitznamen.\""
+msgstr "\"Die Partei bekommt von $unit.dative($renamer) in $region($region) einen Spitznamen.\""
 
 msgid "error_not_on_undead"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Dieser Zauber kann nicht auf Untote gezaubert werden.\""
@@ -1526,9 +1532,6 @@ msgstr "\"$unit($unit) ist im Traum eine Fee erschienen. ($int36($id))\""
 msgid "rust_effect_0"
 msgstr "\"$unit($mage) ruft ein fürchterliches Unwetter über seine Feinde, doch es gab niemanden mehr, den dies treffen konnte.\""
 
-msgid "error1222"
-msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Gebäude gehört uns nicht.\""
-
 msgid "header_battle"
 msgstr "\"In $region($region) findet ein Kampf statt.\""
 
@@ -1536,6 +1539,9 @@ msgid "wormhole_dissolve"
 msgstr "\"Das Wurmloch in $region($region) schließt sich.\""
 
 msgid "error12"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Schiff gehört uns nicht.\""
+
+msgid "not_ship_owner"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Schiff gehört uns nicht.\""
 
 msgid "error34"
@@ -1653,6 +1659,9 @@ msgid "error53"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit kann keine Tränke herstellen.\""
 
 msgid "error20"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Schiff wurde nicht gefunden.\""
+
+msgid "ship_not_found"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Schiff wurde nicht gefunden.\""
 
 msgid "error42"
@@ -1802,7 +1811,7 @@ msgstr "\"$resource($item,1) (Gewicht: $weight($weight)): $description\""
 msgid "error128"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - So viele Fremde kann die Partei nicht aufnehmen.\""
 
-msgid "error247"
+msgid "faction_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Partei hat schon einen Namen.\""
 
 msgid "spellfail_generous"
@@ -2183,6 +2192,9 @@ msgstr "\"$unit($unit) tötete $int($dead) Krieger.\""
 msgid "error6"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Gebäude wurde nicht gefunden.\""
 
+msgid "building_not_found"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Das Gebäude wurde nicht gefunden.\""
+
 msgid "sailnolandingstorm"
 msgstr "\"Die Mannschaft der $ship($ship) kann in letzter Sekunde verhindern, dass das Schiff in $region($region) auf Land aufläuft.\""
 
@@ -2334,7 +2346,7 @@ msgid "curseinfo::sparkle_6"
 msgstr "\"$unit($unit) findet eine kleine Flöte, die eine wundersame Melodie spielt. ($int36($id))\""
 
 msgid "renamed_building_seen"
-msgstr "\"$building($building) in $region($region) bekommt von $unit.dative($renamer) einen Spitznamen.\""
+msgstr "\"$building($renamed) in $region($region) bekommt von $unit.dative($renamer) einen Spitznamen.\""
 
 msgid "sp_shadowknights_effect"
 msgstr "\"$unit($mage) beschwört Trugbilder herauf.\""
@@ -2609,7 +2621,7 @@ msgstr "\"Die $ship($ship) wurde von $ship($follower) verfolgt.\""
 msgid "unitnotfound_id"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Einheit $id wurde nicht gefunden.\""
 
-msgid "error244"
+msgid "unit_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit hat schon einen Namen.\""
 
 msgid "use_tacticcrystal"
@@ -2732,7 +2744,7 @@ msgstr "\"$unit($mage) meint, dass auf $ship($ship) kein Zauber liegt.\""
 msgid "error257"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Ungültiges Locale.\""
 
-msgid "error147"
+msgid "not_region_owner"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit ist nicht Burgherr der größten Burg in der Region.\""
 
 msgid "unknowndirection"
@@ -2803,4 +2815,16 @@ msgstr "\"$unit($unit) in $region($region): $int($number) $race($race,$number) $
 
 msgid "sp_eternizewall_effect"
 msgstr "\"Mit einem Ritual bindet $unit($mage) die magischen Kräfte der Erde von $region($region) in die Mauern von $building($building).\""
+
+msgid "foreign_not_allowed"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - BENENNE FREMD hierfür nicht erlaubt.\""
+
+msgid "not_in_group"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Einheit ist in keiner Gruppe.\""
+
+msgid "not_in_alliance"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Deine Partei ist in keiner Allianz.\""
+
+msgid "not_alliance_owner"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Du bist nicht der Anführer der Allianz.\""
 

--- a/res/translations/messages.en.po
+++ b/res/translations/messages.en.po
@@ -207,7 +207,7 @@ msgid "curseinfo::Feuerwand"
 msgstr "A wall of fire blocks entry and exit. ($int36($id))"
 
 msgid "renamed_building_notseen"
-msgstr "\"$building($building) in $region($region) received a nickname.\""
+msgstr "\"$building($renamed) in $region($region) received a nickname.\""
 
 msgid "heroes_race"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - $race($race,0) cannot be heroes.\""
@@ -303,6 +303,9 @@ msgid "itemcloak"
 msgstr "\"$unit($mage) shrouds the equipment of $unit($target) in shadows.\""
 
 msgid "error5"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - The building is not ours.\""
+
+msgid "not_building_owner"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The building is not ours.\""
 
 msgid "para_tactics_lost"
@@ -417,7 +420,7 @@ msgid "dumbeffect"
 msgstr "\"$unit($unit) eats a duncebuns and forgets $int($weeks) weeks worth of $skill($skill).\""
 
 msgid "renamed_ship_seen"
-msgstr "\"$ship($ship) in $region($region) received a nickname from $unit($renamer).\""
+msgstr "\"$ship($renamed) in $region($region) received a nickname from $unit($renamer).\""
 
 msgid "error126"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - You cannot sell this.\""
@@ -521,13 +524,13 @@ msgstr "\"A tidal wave wipes out $region($region) and kills $unit($unit).\""
 msgid "error14"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The ship is off shore.\""
 
-msgid "renamed_notseen"
+msgid "renamed_unit_notseen"
 msgstr "\"$unit($renamed) in $region($region) received a nickname.\""
 
 msgid "curseinfo::goodmagicresistancezone"
 msgstr "\"The magical resistance of some units in this region was boosted. ($int36($id))\""
 
-msgid "error66"
+msgid "faction_not_found"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The faction could not be found.\""
 
 msgid "error88"
@@ -575,7 +578,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - That region is 
 msgid "para_lineup_battle"
 msgstr "\"Units before turn $int($turn):\""
 
-msgid "error245"
+msgid "ship_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The ship is already named.\""
 
 msgid "sp_chaosrow_effect_0"
@@ -710,6 +713,9 @@ msgstr "\"$unit($unit) is taking poison damage in $region($region).\""
 msgid "error144"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit is not on board a ship.\""
 
+msgid "not_in_ship"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit is not on board a ship.\""
+
 msgid "magicboost_effect"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The Spheres of Chaos return a part of his power to the magician.\""
 
@@ -782,7 +788,7 @@ msgstr "\"A large green snake offers $unit($unit) a fine-looking apple. ($int36(
 msgid "skill_needed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - This requires the skill $skill($skill).\""
 
-msgid "renamed_seen"
+msgid "renamed_unit_seen"
 msgstr "\"$unit($renamed) in $region($region) received a nickname from $unit($renamer).\""
 
 msgid "analyse_unit_nospell"
@@ -848,7 +854,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit must b
 msgid "error_herorecruit"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Heroes cannot recruit.\""
 
-msgid "error109"
+msgid "name_what"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Specify if a castle, a ship, a region, or a unit is supposed to be named.\""
 
 msgid "msg_event"
@@ -872,7 +878,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Empty units can
 msgid "curseinfo::sparkle_7"
 msgstr "\"The women of the nearby village cast furtive looks at $unit($unit). ($int36($id))\""
 
-msgid "error110"
+msgid "display_what"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Specify if description is for a castle, a ship, a region, or a unit.\""
 
 msgid "curseinfo::sparkle_18"
@@ -1149,7 +1155,7 @@ msgid "plant_skills"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - At least $skill($skill) $int($minskill) is needed for planting $resource($product,0).\""
 
 msgid "renamed_ship_notseen"
-msgstr "\"$ship($ship) in $region($region) received a nickname.\""
+msgstr "\"$ship($renamed) in $region($region) received a nickname.\""
 
 msgid "error123"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit does not have such a thing.\""
@@ -1268,7 +1274,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Eine Einheit ka
 msgid "cast_rally_effect"
 msgstr "\"$unit($mage) quells the uprising in $region($region).\""
 
-msgid "error246"
+msgid "building_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The building is already named.\""
 
 msgid "stealaura_fail"
@@ -1436,7 +1442,7 @@ msgstr "\"$unit($unit) in $region($region): '$order($command)' - Who is supposed
 msgid "curseinfo::building_unknown"
 msgstr "\"An unknown spell lies on this building. ($int36($id))\""
 
-msgid "error145"
+msgid "not_in_building"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit is not in a castle.\""
 
 msgid "piratenovictim"
@@ -1509,7 +1515,7 @@ msgid "battle_row"
 msgstr "\"... in combat rank $int($row):\""
 
 msgid "renamed_faction_seen"
-msgstr "\"Your faction received a nickname from $unit($unit) in $region($region).\""
+msgstr "\"Your faction received a nickname from $unit($renamer) in $region($region).\""
 
 msgid "error_not_on_undead"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - This spell cannot be cast upon undead.\""
@@ -1526,9 +1532,6 @@ msgstr "\"In a dream, a fairy appears to $unit($unit). ($int36($id))\""
 msgid "rust_effect_0"
 msgstr "\"$unit($mage) calls forth a terrible torment over the enemy side, but there was nobody who could be affected by it.\""
 
-msgid "error1222"
-msgstr "\"$unit($unit) in $region($region): '$order($command)' - The building is not ours.\""
-
 msgid "header_battle"
 msgstr "\"There is a battle in $region($region).\""
 
@@ -1536,6 +1539,9 @@ msgid "wormhole_dissolve"
 msgstr "\"The wormhole in $region($region) disappears.\""
 
 msgid "error12"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - The ship is not ours.\""
+
+msgid "not_ship_owner"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The ship is not ours.\""
 
 msgid "error34"
@@ -1653,6 +1659,9 @@ msgid "error53"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit cannot make potions.\""
 
 msgid "error20"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - The ship could not be found.\""
+
+msgid "ship_not_found"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The ship could not be found.\""
 
 msgid "error42"
@@ -1802,7 +1811,7 @@ msgstr "\"$resource($item,1) (weight: $weight($weight)): $description\""
 msgid "error128"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The faction cannot hire so many strangers.\""
 
-msgid "error247"
+msgid "faction_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The faction is already named.\""
 
 msgid "spellfail_generous"
@@ -2183,6 +2192,9 @@ msgstr "\"$unit($unit) killed $int($dead) opponents.\""
 msgid "error6"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Building could not be found.\""
 
+msgid "building_not_found"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Building could not be found.\""
+
 msgid "sailnolandingstorm"
 msgstr "\"At the very last moment, the crew of the $ship($ship) saved the ship from running aground in $region($region).\""
 
@@ -2334,7 +2346,7 @@ msgid "curseinfo::sparkle_6"
 msgstr "\"$unit($unit) finds a small flute that plays a beautiful melody. ($int36($id))\""
 
 msgid "renamed_building_seen"
-msgstr "\"$building($building) in $region($region) received a nickname from $unit($renamer).\""
+msgstr "\"$building($renamed) in $region($region) received a nickname from $unit($renamer).\""
 
 msgid "sp_shadowknights_effect"
 msgstr "\"$unit($mage) summons a mirage.\""
@@ -2609,7 +2621,7 @@ msgstr "\"$unit($follower) followed $unit($unit).\""
 msgid "unitnotfound_id"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Unit $id could not be located.\""
 
-msgid "error244"
+msgid "unit_renamed"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit is already named.\""
 
 msgid "use_tacticcrystal"
@@ -2732,7 +2744,7 @@ msgstr "\"It appears to $unit($mage) that $ship($ship) is not charmed.\""
 msgid "error257"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Invalid locale.\""
 
-msgid "error147"
+msgid "not_region_owner"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit is not in command of the largest castle in the region.\""
 
 msgid "unknowndirection"
@@ -2803,4 +2815,16 @@ msgstr "\"$unit($unit) in $region($region): $int($number) $race($race,$number) t
 
 msgid "sp_eternizewall_effect"
 msgstr "\"$unit($mage) performs a ritual that binds the magical forces of $region($region) into the walls of $building($building).\""
+
+msgid "foreign_not_allowed"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - NAME FOREIGN not allowed here.\""
+
+msgid "not_in_group"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - The unit has no group.\""
+
+msgid "not_in_alliance"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - Your faction has no alliance.\""
+
+msgid "not_alliance_owner"
+msgstr "\"$unit($unit) in $region($region): '$order($command)' - You are not the leader of your alliance.\""
 

--- a/scripts/tests/parser.lua
+++ b/scripts/tests/parser.lua
@@ -165,7 +165,7 @@ function test_build_castle()
     process_orders()
     assert_not_nil(u.building)
     assert_equal(1, u.building.size)
-    assert_equal(u.building.name, "Burg")
+    assert_equal(u.building.name, "Burg " .. itoa36(u.building.id))
 end
 
 function test_route()

--- a/src/contact.c
+++ b/src/contact.c
@@ -95,7 +95,7 @@ int contact_cmd(unit * u, order * ord)
         /* new-style syntax, KONTAKTIERE PARTEI foo */
         faction * f = getfaction();
         if (!f) {
-            cmistake(u, ord, 66, MSG_EVENT);
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "faction_not_found", ""));
         }
         else {
             contact_faction(u, f);

--- a/src/kernel/build.c
+++ b/src/kernel/build.c
@@ -764,7 +764,7 @@ build_building(unit * u, const building_type * btype, int id, int want, order * 
             }
             else {
                 /* keine neue Burg anfangen wenn eine Nummer angegeben war */
-                cmistake(u, ord, 6, MSG_PRODUCE);
+                ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "building_not_found", ""));
                 return 0;
             }
         }
@@ -804,7 +804,7 @@ build_building(unit * u, const building_type * btype, int id, int want, order * 
         if (!rule_other) {
             unit *owner = building_owner(b);
             if (!owner || owner->faction != u->faction) {
-                cmistake(u, ord, 1222, MSG_PRODUCE);
+                ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "not_building_owner", ""));
                 return 0;
             }
         }
@@ -984,7 +984,7 @@ void continue_ship(unit * u, int want)
         sh = u->ship;
 
     if (!sh) {
-        cmistake(u, u->thisorder, 20, MSG_PRODUCE);
+        ADDMSG(&u->faction->msgs, msg_feedback(u, u->thisorder, "ship_not_found", ""));
         return;
     }
     msize = ship_maxsize(sh);

--- a/src/kernel/building.c
+++ b/src/kernel/building.c
@@ -422,7 +422,7 @@ building *new_building(const struct building_type * btype, region * r,
     }
     assert(bname);
     snprintf(buffer, sizeof(buffer), "%s %s", bname, itoa36(b->no));
-    b->name = str_strdup(bname);
+    b->name = str_strdup(buffer);
     b->size = size;
     return b;
 }

--- a/src/kernel/building.test.c
+++ b/src/kernel/building.test.c
@@ -7,6 +7,7 @@
 #include <kernel/building.h>
 #include <kernel/unit.h>
 
+#include <util/base36.h>
 #include <util/language.h>
 #include <util/strings.h>
 
@@ -680,6 +681,20 @@ static void test_buildingcapacity(CuTest *tc) {
     test_teardown();
 }
 
+static void test_building_defaultname(CuTest *tc) {
+    building *b;
+    building_type *btype;
+    char name[NAMESIZE];
+    test_setup();
+    btype = test_create_buildingtype("herp");
+    b = test_create_building(test_create_region(0, 0, NULL), btype);
+
+    snprintf(name, sizeof(name), "herp %s", itoa36(b->no));
+    CuAssertStrEquals(tc, name, building_getname(b));
+
+    test_teardown();
+}
+
 CuSuite *get_building_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -707,5 +722,6 @@ CuSuite *get_building_suite(void)
     SUITE_ADD_TEST(suite, test_active_building);
     SUITE_ADD_TEST(suite, test_buildingtype_exists);
     SUITE_ADD_TEST(suite, test_safe_building);
+    SUITE_ADD_TEST(suite, test_building_defaultname);
     return suite;
 }

--- a/src/laws.c
+++ b/src/laws.c
@@ -1008,7 +1008,7 @@ int quit_cmd(unit * u, struct order *ord)
 #ifdef QUIT_WITH_TRANSFER
                 faction *f2 = getfaction();
                 if (f2 == NULL || f2 == u->faction) {
-                    cmistake(u, ord, 66, MSG_EVENT);
+                    ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "faction_not_found", ""));
                     flags = 0;
                 }
                 else if (f->race != f2->race) {
@@ -1093,7 +1093,7 @@ int enter_ship(unit * u, struct order *ord, int id, bool report)
     sh = findship(id);
     if (sh == NULL || sh->number < 1 || sh->region != r) {
         if (report) {
-            cmistake(u, ord, 20, MSG_MOVE);
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "ship_not_found", ""));
         }
         return 0;
     }
@@ -1159,7 +1159,7 @@ int enter_building(unit * u, order * ord, int id, bool report)
     b = findbuilding(id);
     if (b == NULL || b->region != r) {
         if (report) {
-            cmistake(u, ord, 6, MSG_MOVE);
+          ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "building_not_found", ""));
         }
         return 0;
     }
@@ -1377,7 +1377,7 @@ int ally_cmd(unit * u, struct order *ord)
     f = getfaction();
 
     if (f == NULL || is_monsters(f)) {
-        cmistake(u, ord, 66, MSG_EVENT);
+        ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "faction_not_found", ""));
         return 0;
     }
     if (f == u->faction)
@@ -1552,7 +1552,7 @@ int prefix_cmd(unit * u, struct order *ord)
         group *g = get_group(u);
         if (g) {
             ap = &g->attribs;
-        } 
+        }
         else {
             ap = &u->faction->attribs;
         }
@@ -1561,394 +1561,359 @@ int prefix_cmd(unit * u, struct order *ord)
     return 0;
 }
 
-int display_cmd(unit * u, struct order *ord)
-{
+static void generic_setname(char **oldname, const char *newname) {
+    free(*oldname);
+    if (newname)
+        *oldname = str_strdup(newname);
+    else
+        *oldname = NULL;
+}
+
+int text_cmd(unit *u, order *ord, const keyword_t cmd) {
     char token[128];
-    char **s = NULL;
-    char *str;
-    region *r = u->region;
-
-    init_order(ord, NULL);
-
-    str = gettoken(token, sizeof(token));
-    switch (findparam_ex(str, u->faction->locale)) {
-    case P_BUILDING:
-    case P_GEBAEUDE:
-        if (!u->building) {
-            cmistake(u, ord, 145, MSG_PRODUCE);
-            break;
-        }
-        if (building_owner(u->building) != u) {
-            cmistake(u, ord, 5, MSG_PRODUCE);
-            break;
-        }
-        if (!fval(u->building->type, BTF_NAMECHANGE) && u->building->display && u->building->display[0]) {
-            cmistake(u, ord, 278, MSG_EVENT);
-            break;
-        }
-        s = &u->building->display;
-        break;
-
-    case P_SHIP:
-        if (!u->ship) {
-            cmistake(u, ord, 144, MSG_PRODUCE);
-            break;
-        }
-        if (ship_owner(u->ship) != u) {
-            cmistake(u, ord, 12, MSG_PRODUCE);
-            break;
-        }
-        s = &u->ship->display;
-        break;
-
-    case P_UNIT:
-        str = getstrtoken();
-        if (str) {
-            unicode_utf8_trim(str);
-        }
-        unit_setinfo(u, str);
-        break;
-
-    case P_PRIVAT:
-        str = getstrtoken();
-        if (str) {
-            unicode_utf8_trim(str);
-        }
-        usetprivate(u, str);
-        break;
-
-    case P_REGION:
-        if (!r->land || u->faction != region_get_owner(r)) {
-            cmistake(u, ord, 147, MSG_EVENT);
-            break;
-        }
-        s = &r->land->display;
-        break;
-
-    default:
-        cmistake(u, ord, 110, MSG_EVENT);
-        break;
-    }
-
-    if (s != NULL) {
-        const char *s2 = getstrtoken();
-
-        free(*s);
-        if (s2) {
-            char * sdup = str_strdup(s2);
-            if (unicode_utf8_trim(sdup) != 0) {
-                log_info("trimming info: %s", s2);
-            }
-            if (strlen(sdup) >= DISPLAYSIZE) {
-                sdup[DISPLAYSIZE-1] = 0;
-            }
-            *s = sdup;
-        }
-        else {
-            *s = NULL;
-        }
-    }
-
-    return 0;
-}
-
-bool renamed_building(const building * b)
-{
-    const struct locale *lang = locales;
-    size_t len = strlen(b->name);
-    for (; lang; lang = nextlocale(lang)) {
-        const char *bdname = LOC(lang, b->type->_name);
-        if (bdname) {
-            size_t bdlen = strlen(bdname);
-            if (len >= bdlen && strncmp(b->name, bdname, bdlen) == 0) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-static int rename_cmd(unit * u, order * ord, char **s, const char *s2)
-{
-	char name[NAMESIZE];
-    assert(s2);
-    if (!s2[0]) {
-        cmistake(u, ord, 84, MSG_EVENT);
-        return 0;
-    }
-
-    /* TODO: Validate to make sure people don't have illegal characters in
-     * names, phishing-style? () come to mind. */
-    str_strlcpy(name, s2, sizeof(name));
-    if (unicode_utf8_trim(name) != 0) {
-        log_info("trimming name: %s", s2);
-    }
-
-    free(*s);
-    *s = str_strdup(name);
-    return 0;
-}
-
-static bool try_rename(unit *u, building *b, order *ord) {
-    unit *owner = b ? building_owner(b) : NULL;
-    bool foreign = !(owner && owner->faction == u->faction);
-
-    if (!b) {
-        cmistake(u, ord, u->building ? 6 : 145, MSG_EVENT);
-        return false;
-    }
-
-    if (!fval(b->type, BTF_NAMECHANGE) && renamed_building(b)) {
-        cmistake(u, ord, 278, MSG_EVENT);
-        return false;
-    }
-
-    if (foreign) {
-        if (renamed_building(b)) {
-            cmistake(u, ord, 246, MSG_EVENT);
-            return false;
-        }
-
-        if (owner) {
-            if (cansee(owner->faction, u->region, u, 0)) {
-                ADDMSG(&owner->faction->msgs,
-                    msg_message("renamed_building_seen",
-                        "building renamer region", b, u, u->region));
-            }
-            else {
-                ADDMSG(&owner->faction->msgs,
-                    msg_message("renamed_building_notseen",
-                        "building region", b, u->region));
-            }
-        }
-    }
-    if (owner && owner->faction != u->faction) {
-        cmistake(u, ord, 148, MSG_PRODUCE);
-        return false;
-    }
-    return true;
-}
-
-int
-rename_building(unit * u, order * ord, building * b, const char *name)
-{
-    assert(name);
-    if (!try_rename(u, b, ord)) {
-        return -1;
-    }
-    return rename_cmd(u, ord, &b->name, name);
-}
-
-int name_cmd(struct unit *u, struct order *ord)
-{
-    char token[128];
-    building *b = u->building;
-    region *r = u->region;
-    char **s = NULL;
     param_t p;
     bool foreign = false;
     const char *str;
+    faction *f = u->faction;
+    region *r = u->region;
+    building *b = u->building;
+    ship *sh = u->ship;
+    unit *u2 = NULL;
+    unit *owner = NULL;
+    faction *ownerfaction = NULL;
+    alliance *all = NULL;
+    group *g = NULL;
+    void *object = NULL;
+    int ngenerics = 0;
+    const char *generics[2];
+    const char *oldname = NULL;
+    char *newname = NULL;
 
-    init_order(ord, u->faction->locale);
+    const char *error_notfound = NULL;
+    const char *error_notowner = NULL;
+    const char *error_renamed = NULL;
+    const char *error_unnamable = "error278";
+    const char *message_seen = NULL;
+    const char *message_unseen = NULL;
+
+    init_order(ord, NULL);
     str = gettoken(token, sizeof(token));
     p = findparam_ex(str, u->faction->locale);
-
-    if (p == P_FOREIGN) {
-        str = gettoken(token, sizeof(token));
+    if (cmd == K_DISPLAY) {
+        switch (p) {
+        case P_BUILDING:
+        case P_GEBAEUDE:
+            object = b;
+            owner = b ? building_owner(b) : NULL;
+            error_notfound = "not_in_building";
+            error_notowner = "not_building_owner";
+            break;
+        case P_SHIP:
+            object = sh;
+            owner = sh ? ship_owner(sh) : NULL;
+            error_notfound = "not_in_ship";
+            error_notowner = "not_ship_owner";
+            break;
+        case P_UNIT:
+            object = u;
+            owner = u;
+            break;
+        case P_PRIVAT:
+            object = u;
+            owner = u;
+            break;
+        case P_FACTION:
+            object = f;
+            owner = u;
+            break;
+        case P_REGION:
+            object = r;
+            if (r->land && u->faction == region_get_owner(r))
+            owner = u;
+            error_notowner = "not_region_owner";
+            break;
+        default:
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "display_what", ""));
+            return 0;
+        }
+        ownerfaction = owner ? owner->faction : NULL;
+    } else if (p == P_FOREIGN) {
         foreign = true;
+        str = gettoken(token, sizeof(token));
         p = findparam_ex(str, u->faction->locale);
-    }
-
-    switch (p) {
-    case P_ALLIANCE:
-        if (!foreign && f_get_alliance(u->faction)) {
-            alliance *al = u->faction->alliance;
-            faction *lead = alliance_get_leader(al);
-            if (lead == u->faction) {
-                s = &al->name;
+        switch (p) {
+        case P_BUILDING:
+        case P_GEBAEUDE:
+            object = b = getbuilding(u->region);
+            error_notfound = "building_not_found";
+            error_renamed = "building_renamed";
+            message_seen = "renamed_building_seen";
+            message_unseen = "renamed_building_notseen";
+            if (b) {
+                owner = building_owner(b);
+                oldname = building_getname(b);
+                ngenerics = 2;
+                generics[0] = b->type->_name;
+                generics[1] = "site";
             }
-        }
-        break;
-    case P_BUILDING:
-    case P_GEBAEUDE:
-        if (foreign) {
-            b = getbuilding(u->region);
-        }
-        if (try_rename(u, b, ord)) {
-            s = &b->name;
-        }
-        break;
-    case P_FACTION:
-        if (foreign) {
-            faction *f;
-
-            f = getfaction();
-            if (!f) {
-                cmistake(u, ord, 66, MSG_EVENT);
-                break;
+            break;
+        case P_SHIP:
+            object = sh = getship(u->region);
+            error_notfound = "ship_not_found";
+            error_renamed = "ship_renamed";
+            message_seen = "renamed_ship_seen";
+            message_unseen = "renamed_ship_notseen";
+            if (sh) {
+                owner = ship_owner(sh);
+                oldname = ship_getname(sh);
+                ngenerics = 2;
+                generics[0] = sh->type->_name;
+                generics[1] = parameters[P_SHIP];
             }
-            if (f->age < 10) {
-                cmistake(u, ord, 248, MSG_EVENT);
-                break;
+            break;
+        case P_FACTION:
+            object = f = getfaction();
+            error_notfound = "faction_not_found";
+            error_renamed = "faction_renamed";
+            message_seen = "renamed_faction_seen";
+            message_unseen = "renamed_faction_notseen";
+            if (f) {
+                ownerfaction = f;
+                oldname = faction_getname(f);
+                ngenerics = 1;
+                generics[0] = "factiondefault";
             }
-            else {
-                const struct locale *lang = locales;
-                size_t f_len = strlen(f->name);
-                for (; lang; lang = nextlocale(lang)) {
-                    const char *fdname = LOC(lang, "factiondefault");
-                    size_t fdlen = strlen(fdname);
-                    if (f_len >= fdlen && strncmp(f->name, fdname, fdlen) == 0) {
-                        break;
-                    }
-                }
-                if (lang == NULL) {
-                    cmistake(u, ord, 247, MSG_EVENT);
-                    break;
-                }
+            break;
+        case P_UNIT:
+            getunit(u->region, u->faction, &u2);
+            object = u2;
+            error_notfound = "feedback_unit_not_found";
+            error_renamed = "unit_renamed";
+            message_seen = "renamed_unit_seen";
+            message_unseen = "renamed_unit_notseen";
+            if (u2) {
+                owner = u2;
+                oldname = unit_getname(u2);
+                ngenerics = 1;
+                generics[0] = "unitdefault";
             }
-            if (cansee(f, r, u, 0)) {
-                ADDMSG(&f->msgs,
-                    msg_message("renamed_faction_seen", "unit region", u, r));
-            }
-            else {
-                ADDMSG(&f->msgs, msg_message("renamed_faction_notseen", "", r));
-            }
-            s = &f->name;
-        }
-        else {
-            s = &u->faction->name;
-        }
-        break;
-
-    case P_SHIP:
-        if (foreign) {
-            ship *sh = getship(r);
-            unit *uo;
-
-            if (!sh) {
-                cmistake(u, ord, 20, MSG_EVENT);
-                break;
-            }
-            else {
-                const struct locale *lang = locales;
-                size_t sh_len = strlen(sh->name);
-                for (; lang; lang = nextlocale(lang)) {
-                    const char *sdname = LOC(lang, sh->type->_name);
-                    size_t sdlen = strlen(sdname);
-                    if (sh_len >= sdlen && strncmp(sh->name, sdname, sdlen) == 0) {
-                        break;
-                    }
-
-                    sdname = LOC(lang, parameters[P_SHIP]);
-                    sdlen = strlen(sdname);
-                    if (sh_len >= sdlen && strncmp(sh->name, sdname, sdlen) == 0) {
-                        break;
-                    }
-
-                }
-                if (lang == NULL) {
-                    cmistake(u, ord, 245, MSG_EVENT);
-                    break;
-                }
-            }
-            uo = ship_owner(sh);
-            if (uo) {
-                if (cansee(uo->faction, r, u, 0)) {
-                    ADDMSG(&uo->faction->msgs,
-                        msg_message("renamed_ship_seen", "ship renamer region", sh, u, r));
-                }
-                else {
-                    ADDMSG(&uo->faction->msgs,
-                        msg_message("renamed_ship_notseen", "ship region", sh, r));
-                }
-            }
-            s = &sh->name;
-        }
-        else {
-            unit *uo;
-            if (!u->ship) {
-                cmistake(u, ord, 144, MSG_PRODUCE);
-                break;
-            }
-            uo = ship_owner(u->ship);
-            if (uo->faction != u->faction) {
-                cmistake(u, ord, 12, MSG_PRODUCE);
-                break;
-            }
-            s = &u->ship->name;
-        }
-        break;
-
-    case P_UNIT:
-        if (foreign) {
-            unit *u2 = 0;
-
-            getunit(r, u->faction, &u2);
-            if (!u2 || !cansee(u->faction, r, u2, 0)) {
-                ADDMSG(&u->faction->msgs, msg_feedback(u, ord,
-                    "feedback_unit_not_found", ""));
-                break;
-            }
-            else {
-                char udefault[32];
-                default_name(u2, udefault, sizeof(udefault));
-                if (strcmp(unit_getname(u2), udefault) != 0) {
-                    cmistake(u, ord, 244, MSG_EVENT);
-                    break;
-                }
-            }
-            if (cansee(u2->faction, r, u, 0)) {
-                ADDMSG(&u2->faction->msgs, msg_message("renamed_seen",
-                    "renamer renamed region", u, u2, r));
-            }
-            else {
-                ADDMSG(&u2->faction->msgs, msg_message("renamed_notseen",
-                    "renamed region", u2, r));
-            }
-            s = &u2->_name;
-        }
-        else {
-            s = &u->_name;
-        }
-        break;
-
-    case P_REGION:
-        if (u->faction != region_get_owner(r)) {
-            cmistake(u, ord, 147, MSG_EVENT);
+            break;
+        case P_ALLIANCE:
+        case P_REGION:
+        case P_GROUP:
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "foreign_not_allowed", ""));
+            return 0;
+            break;
+        default:
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "name_what", ""));
+            return 0;
             break;
         }
-        s = &r->land->name;
-        break;
-
-    case P_GROUP:
-    {
-        group *g = get_group(u);
-        if (g) {
-            s = &g->name;
+        if (!ownerfaction && owner) {
+            ownerfaction = owner->faction;
+        }
+    } else {
+        switch (p) {
+        case P_BUILDING:
+        case P_GEBAEUDE:
+            object = b;
+            owner = b ? building_owner(b) : NULL;
+            error_notfound = "not_in_building";
+            error_notowner = "not_building_owner";
+            break;
+        case P_SHIP:
+            object = sh;
+            owner = sh ? ship_owner(sh) : NULL;
+            error_notfound = "not_in_ship";
+            error_notowner = "not_ship_owner";
+            break;
+        case P_FACTION:
+            object = f;
+            owner = u;
+            break;
+        case P_UNIT:
+            u2 = u;
+            object = u;
+            owner = u;
+            break;
+        case P_ALLIANCE:
+            all = f_get_alliance(u->faction);
+            object = all;
+            if (all && alliance_get_leader(all) == u->faction)
+            owner = u;
+            error_notfound = "not_in_alliance";
+            error_notowner = "not_alliance_owner";
+            break;
+        case P_REGION:
+            object = r;
+            if (r->land && u->faction == region_get_owner(r))
+            owner = u;
+            error_notowner = "not_region_owner";
+            break;
+        case P_GROUP:
+            object = g = get_group(u);
+            owner = u;
+            error_notfound = "not_in_group";
+            break;
+        default:
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "name_what", ""));
+            return 0;
             break;
         }
-        else {
-            cmistake(u, ord, 109, MSG_EVENT);
-            break;
-        }
+        ownerfaction = owner ? owner->faction : NULL;
     }
-    break;
-    default:
-        cmistake(u, ord, 109, MSG_EVENT);
-        break;
+    if (!object) {
+        assert(error_notfound);
+        ADDMSG(&u->faction->msgs, msg_feedback(u, ord, error_notfound, ""));
+        return 0;
     }
 
-    if (s != NULL) {
-        const char *name = getstrtoken();
-        if (name) {
-            rename_cmd(u, ord, s, name);
+    if (!foreign && owner != u) {
+        assert(error_notowner);
+        ADDMSG(&u->faction->msgs, msg_feedback(u, ord, error_notowner, ""));
+        return 0;
+    }
+
+    if (object == b && !fval(b->type, BTF_NAMECHANGE)
+        && ((cmd == K_DISPLAY && u->building->display && u->building->display[0])
+            || (cmd == K_NAME && renamed_thing(b->name, b->type->_name)))) {
+        ADDMSG(&u->faction->msgs, msg_feedback(u, ord, error_unnamable, ""));
+        return 0;
+    }
+
+    if (ngenerics && foreign) {
+        int i;
+        bool renamed = true;
+        for (i = 0; renamed && i < ngenerics; ++i) {
+            if (!renamed_thing(oldname, generics[i])) {
+                renamed = false;
+            }
         }
-        else {
+        if (renamed) {
+            assert(error_renamed);
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, error_renamed, ""));
+            return 0;
+        }
+    }
+
+    str = getstrtoken();
+    if (str) {
+        size_t maxlen = cmd == K_DISPLAY ? DISPLAYSIZE : NAMESIZE;
+        newname = str_strdup(str);
+        if (unicode_utf8_trim(newname) != 0) {
+            log_info("trimming info: %s", str);
+        }
+        if (strlen(newname) >= maxlen) {
+            newname[maxlen - 1] = 0;
+        }
+        if (newname && strlen(newname) == 0) {
+            free(newname);
+            newname = NULL;
+        }
+    }
+
+    if (cmd == K_DISPLAY) {
+        switch (p) {
+        case P_BUILDING:
+        case P_GEBAEUDE:
+            generic_setname(&b->display, newname);
+            break;
+        case P_SHIP:
+            generic_setname(&sh->display, newname);
+            break;
+        case P_UNIT:
+            unit_setinfo(u, newname);
+            break;
+        case P_PRIVAT:
+            usetprivate(u, newname);
+            break;
+        case P_FACTION:
+            faction_setbanner(f, newname);
+            break;
+        case P_REGION:
+            generic_setname(&r->land->display, newname);
+            break;
+        default:
+            break;
+        }
+    } else {
+        if (!newname) {
             cmistake(u, ord, 84, MSG_EVENT);
+            return 0;
+        }
+        switch (p) {
+        case P_BUILDING:
+        case P_GEBAEUDE:
+            building_setname(b, newname);
+            break;
+        case P_SHIP:
+            ship_setname(sh, newname);
+            break;
+        case P_FACTION:
+            faction_setname(f, newname);
+            break;
+        case P_UNIT:
+            unit_setname(u2, newname);
+            break;
+        case P_ALLIANCE:
+            alliance_setname(all, newname);
+            break;
+        case P_REGION:
+            region_setname(r, newname);
+            break;
+        case P_GROUP:
+            generic_setname(&g->name, newname);
+            break;
+        default:
+            break;
+        }
+        if (foreign && ownerfaction) {
+            if (cansee(ownerfaction, r, u, 0)) {
+                assert(message_seen);
+                ADDMSG(&ownerfaction->msgs, msg_message(message_seen,
+                    "renamer renamed region", u, object, r));
+            } else {
+                assert(message_unseen);
+                ADDMSG(&ownerfaction->msgs, msg_message(message_unseen,
+                    "renamed region", object, r));
+            }
         }
     }
+    free(newname);
 
     return 0;
+}
+
+int display_cmd(unit * u, struct order *ord) {
+    return text_cmd(u, ord, K_DISPLAY);
+}
+
+bool renamed_thing(const char *name, const char *typename)
+{
+    const struct locale *lang = locales;
+    size_t namelen = strlen(name);
+
+    for (; lang; lang = nextlocale(lang)) {
+        const char *localname = LOC(lang, typename);
+        if (localname) {
+            size_t typelen = strlen(localname);
+            if (namelen < typelen || namelen > typelen + 5)
+                continue;
+            if (namelen == typelen)
+                return false;
+            if (strncmp(name, localname, typelen) != 0)
+                continue;
+            if (name[typelen] != ' ')
+                continue;
+            if (atoi36(name+typelen+1) > 0)
+                return false;
+        }
+    }
+    return true;
+}
+
+int name_cmd(struct unit *u, struct order *ord) {
+  return text_cmd(u, ord, K_NAME);
 }
 
 /* ------------------------------------------------------------- */
@@ -1995,7 +1960,7 @@ static void mailfaction(unit * u, int n, struct order *ord, const char *s)
     if (f && n > 0)
         deliverMail(f, u->region, u, s, NULL);
     else
-        cmistake(u, ord, 66, MSG_MESSAGE);
+        ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "faction_not_found", ""));
 }
 
 int mail_cmd(unit * u, struct order *ord)
@@ -2037,7 +2002,7 @@ int mail_cmd(unit * u, struct order *ord)
             }
 
             if (!u2) {
-                cmistake(u, ord, 66, MSG_MESSAGE);
+                ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "faction_not_found", ""));
                 break;
             }
 
@@ -2080,7 +2045,7 @@ int mail_cmd(unit * u, struct order *ord)
             building *b = getbuilding(r);
 
             if (!b) {
-                cmistake(u, ord, 6, MSG_MESSAGE);
+                ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "building_not_found", ""));
                 break;
             }
 
@@ -2109,7 +2074,7 @@ int mail_cmd(unit * u, struct order *ord)
             ship *sh = getship(r);
 
             if (!sh) {
-                cmistake(u, ord, 20, MSG_MESSAGE);
+                ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "ship_not_found", ""));
                 break;
             }
 
@@ -2860,7 +2825,7 @@ static void ageing(void)
         for (up = &r->units; *up;) {
             unit *u = *up;
             a_age(&u->attribs, u);
-            if (u == *up) 
+            if (u == *up)
                 handle_event(u->attribs, "timer", u);
             if (u == *up) /*-V581 */
                 up = &(*up)->next;
@@ -2924,7 +2889,7 @@ int checkunitnumber(const faction * f, int add)
     return 0;
 }
 
-void maketemp_cmd(unit *u, order **olist) 
+void maketemp_cmd(unit *u, order **olist)
 {
     order *makeord;
     int err = checkunitnumber(u->faction, 1);
@@ -3442,7 +3407,7 @@ int use_cmd(unit * u, struct order *ord)
 int pay_cmd(unit * u, struct order *ord)
 {
     if (!u->building) {
-        cmistake(u, ord, 6, MSG_EVENT);
+        ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "building_not_found", ""));
     }
     else {
         param_t p;
@@ -3456,7 +3421,7 @@ int pay_cmd(unit * u, struct order *ord)
             /* If the unit is not the owner of the building: error */
             if (owner->no != u->no) {
                 /* The building is not ours error */
-                cmistake(u, ord, 1222, MSG_EVENT);
+                ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "not_building_owner", ""));
             }
             else {
                 /* If no building id is given or it is the id of our building, just set the do-not-pay flag */
@@ -3477,14 +3442,14 @@ int pay_cmd(unit * u, struct order *ord)
                         else
                         {
                             /* The building is not ours error */
-                            cmistake(u, ord, 1222, MSG_EVENT);
+                            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "not_building_owner", ""));
                         }
 
                     }
                     else
                     {
                         /* Building not found error */
-                        cmistake(u, ord, 6, MSG_PRODUCE);
+                        ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "building_not_found", ""));
                     }
                 }
             }
@@ -3949,7 +3914,7 @@ void init_processor(void)
     add_proc_unit(p, follow_cmds, "Folge auf Einheiten setzen");
     add_proc_order(p, K_QUIT, quit_cmd, 0, "Stirb");
 
-    /* all recruitment must be finished before we can calculate 
+    /* all recruitment must be finished before we can calculate
      * promotion cost of ability */
     p += 10;
     add_proc_global(p, quit, "Sterben");

--- a/src/laws.h
+++ b/src/laws.h
@@ -28,8 +28,7 @@ extern "C" {
     void deliverMail(struct faction *f, struct region *r, struct unit *u,
         const char *s, struct unit *receiver);
 
-    bool renamed_building(const struct building * b);
-    int rename_building(struct unit * u, struct order * ord, struct building * b, const char *name);
+    bool renamed_thing(const char *name, const char *typename);
     void get_food(struct region * r);
 
     int enter_building(struct unit *u, struct order *ord, int id, bool report);

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -76,6 +76,10 @@ static void test_renamed_thing(CuTest * tc)
     CuAssertTrue(tc, !renamed_thing(b->name, b->type->_name));
     building_setname(b, "castle bLut");
     CuAssertTrue(tc, !renamed_thing(b->name, b->type->_name));
+    building_setname(b, "castlf");
+    CuAssertTrue(tc, renamed_thing(b->name, b->type->_name));
+    building_setname(b, "CASTLE");
+    CuAssertTrue(tc, !renamed_thing(b->name, b->type->_name));
     test_teardown();
 }
 
@@ -1506,6 +1510,7 @@ static void test_name_foreign_unseen(CuTest *tc) {
         LOC(f->locale, parameters[P_FACTION]),
         itoa36(ux->faction->no));
     name_cmd(u, u->thisorder);
+    CuAssert(tc, "cs", !cansee(ux->faction, u->region, u, 0));
     CuAssertStrEquals(tc, "Hodor", ux->faction->name);
     CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_faction_notseen"));
     test_clear_messages(f);

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -11,6 +11,7 @@
 #include <kernel/config.h>
 #include <kernel/building.h>
 #include <kernel/faction.h>
+#include <kernel/group.h>
 #include <kernel/item.h>
 #include <kernel/messages.h>
 #include <kernel/order.h>
@@ -45,11 +46,11 @@ static void test_new_building_can_be_renamed(CuTest * tc)
     r = test_create_region(0, 0, NULL);
 
     b = test_create_building(r, NULL);
-    CuAssertTrue(tc, !renamed_building(b));
+    CuAssertTrue(tc, !renamed_thing(b->name, b->type->_name));
     test_teardown();
 }
 
-static void test_rename_building(CuTest * tc)
+static void test_renamed_thing(CuTest * tc)
 {
     region *r;
     building *b;
@@ -66,34 +67,15 @@ static void test_rename_building(CuTest * tc)
     u = test_create_unit(f, r);
     u_set_building(u, b);
 
-    rename_building(u, NULL, b, "Villa Nagel");
+    CuAssertStrEquals(tc, "castle", b->type->_name);
+    CuAssertTrue(tc, !renamed_thing(b->name, b->type->_name));
+    building_setname(b, "Villa Nagel");
     CuAssertStrEquals(tc, "Villa Nagel", b->name);
-    CuAssertTrue(tc, renamed_building(b));
-    test_teardown();
-}
-
-static void test_rename_building_twice(CuTest * tc)
-{
-    region *r;
-    unit *u;
-    faction *f;
-    building *b;
-    building_type *btype;
-
-    test_setup();
-    test_create_locale();
-    btype = test_create_buildingtype("castle");
-    r = test_create_region(0, 0, NULL);
-    b = new_building(btype, r, default_locale, 1);
-    f = test_create_faction();
-    u = test_create_unit(f, r);
-    u_set_building(u, b);
-
-    rename_building(u, NULL, b, "Villa Nagel");
-    CuAssertStrEquals(tc, "Villa Nagel", b->name);
-
-    rename_building(u, NULL, b, "Villa Kunterbunt");
-    CuAssertStrEquals(tc, "Villa Kunterbunt", b->name);
+    CuAssertTrue(tc, renamed_thing(b->name, b->type->_name));
+    building_setname(b, "castle");
+    CuAssertTrue(tc, !renamed_thing(b->name, b->type->_name));
+    building_setname(b, "castle bLut");
+    CuAssertTrue(tc, !renamed_thing(b->name, b->type->_name));
     test_teardown();
 }
 
@@ -175,9 +157,15 @@ static void test_enter_ship(CuTest * tc)
 
 static void test_display_cmd(CuTest *tc) {
     unit *u;
+    unit *ux;
     faction *f;
     region *r;
     order *ord;
+    building *b;
+    char longname[DISPLAYSIZE + 10];
+    memset(longname, 'x', sizeof(longname));
+    longname[DISPLAYSIZE + 9] = 0;
+
 
     test_setup();
     r = test_create_region(0, 0, test_create_terrain("plain", LAND_REGION));
@@ -185,6 +173,8 @@ static void test_display_cmd(CuTest *tc) {
     assert(r && f);
     u = test_create_unit(f, r);
     assert(u);
+
+    b = test_create_building(r, NULL);
 
     ord = create_order(K_DISPLAY, f->locale, "%s Hodor", LOC(f->locale, parameters[P_UNIT]));
     CuAssertIntEquals(tc, 0, display_cmd(u, ord));
@@ -211,10 +201,47 @@ static void test_display_cmd(CuTest *tc) {
     CuAssertPtrEquals(tc, NULL, (void *)unit_getinfo(u));
     free_order(ord);
 
+    CuAssertPtrEquals(tc, NULL, region_get_owner(r));
+    r->land->display = str_strdup("Somthin");
     ord = create_order(K_DISPLAY, f->locale, "%s Hodor", LOC(f->locale, parameters[P_REGION]));
     CuAssertIntEquals(tc, 0, display_cmd(u, ord));
-    CuAssertPtrEquals(tc, NULL, r->land->display);
+    CuAssertStrEquals(tc, "Somthin", r->land->display);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "not_region_owner"));
     free_order(ord);
+
+    ord = create_order(K_DISPLAY, f->locale, "Hodor");
+    CuAssertIntEquals(tc, 0, display_cmd(u, ord));
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "display_what"));
+    CuAssertStrEquals(tc, "Somthin", r->land->display);
+    free_order(ord);
+
+    b->size = 10;
+    u_set_building(u, b);
+    building_set_owner(u);
+    CuAssertPtrEquals(tc, u->faction, region_get_owner(r));
+    ord = create_order(K_DISPLAY, f->locale, "%s ", LOC(f->locale, parameters[P_REGION]));
+    CuAssertIntEquals(tc, 0, display_cmd(u, ord));
+    free_order(ord);
+
+    ord = create_order(K_DISPLAY, f->locale, "%s Hodor", LOC(f->locale, parameters[P_REGION]));
+    CuAssertIntEquals(tc, 0, display_cmd(u, ord));
+    CuAssertStrEquals(tc, "Hodor", r->land->display);
+    free_order(ord);
+
+    ord = create_order(K_DISPLAY, f->locale, "%s \"%s\"", LOC(f->locale, parameters[P_UNIT]), longname);
+    display_cmd(u, ord);
+    /* not equal because total size of ord might be DISPLAYSIZE */
+    CuAssertTrue(tc, strlen(unit_getinfo(u)) <= DISPLAYSIZE - 1);
+    free_order(ord);
+
+    ux = test_create_unit(test_create_faction(), r);
+    ord = create_order(K_DISPLAY, f->locale, "%s %s %s \"%s\"",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_UNIT]),
+        itoa36(ux->no), "Hodor");
+    display_cmd(u, ord);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "display_what"));
+    CuAssertPtrEquals(tc, NULL, (void *) unit_getinfo(ux));
 
     test_teardown();
 }
@@ -911,9 +938,10 @@ static unit * setup_name_cmd(void) {
     test_setup();
     mt_create_error(84);
     mt_create_error(148);
-    mt_create_error(12);
     mt_create_va(mt_new("renamed_building_seen", NULL), "renamer:unit", "region:region", "building:building", MT_NEW_END);
     mt_create_va(mt_new("renamed_building_notseen", NULL), "region:region", "building:building", MT_NEW_END);
+    mt_create_feedback("not_region_owner");
+    mt_create_feedback("not_in_ship");
     f = test_create_faction();
     return test_create_unit(f, test_create_region(0, 0, NULL));
 }
@@ -977,9 +1005,13 @@ static void test_name_building(CuTest *tc) {
     unit *uo, *u, *ux;
     faction *f;
     order *ord;
+    building *b;
+    building_type *bt;
 
     u = setup_name_cmd();
-    u->building = test_create_building(u->region, NULL);
+    bt = test_create_buildingtype("castle");
+    b = test_create_building(u->region, bt);
+    u->building = b;
     f = u->faction;
     uo = test_create_unit(test_create_faction(), test_create_region(0, 0, NULL));
     u_set_building(uo, u->building);
@@ -989,7 +1021,7 @@ static void test_name_building(CuTest *tc) {
     ord = create_order(K_NAME, f->locale, "%s ' Hodor Hodor '", LOC(f->locale, parameters[P_BUILDING]));
     building_set_owner(uo);
     name_cmd(u, ord);
-    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "error148"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "not_building_owner"));
     test_clear_messages(f);
     building_set_owner(u);
     name_cmd(u, ord);
@@ -1000,25 +1032,35 @@ static void test_name_building(CuTest *tc) {
     name_cmd(u, ord);
     CuAssertStrEquals(tc, "Hodor", u->building->name);
 
-    building_setname(u->building, "Home");
+    building_setname(b, "Home");
+    u_set_building(u, NULL);
+    name_cmd(u, ord);
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "not_in_building"));
+    CuAssertStrEquals(tc, "Home", b->name);
+    test_clear_messages(f);
+    u_set_building(u, b);
+
     building_set_owner(ux);
     name_cmd(u, ord);
-    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "error148"));
-    CuAssertStrEquals(tc, "Hodor", u->building->name);
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "not_building_owner"));
+    CuAssertStrEquals(tc, "Home", u->building->name);
     test_clear_messages(f);
+    building_set_owner(u);
+
+    freset(bt, BTF_NAMECHANGE);
+    name_cmd(u, ord);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "error278"));
+    CuAssertStrEquals(tc, "Home", u->building->name);
+    test_clear_messages(f);
+    fset(bt, BTF_NAMECHANGE);
     free_order(ord);
 
     ord = create_order(K_NAME, f->locale, LOC(f->locale, parameters[P_BUILDING]));
     name_cmd(u, ord);
     CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "error84"));
-    CuAssertStrEquals(tc, "Hodor", u->building->name);
+    CuAssertStrEquals(tc, "Home", u->building->name);
     free_order(ord);
 
-    /* TODO: test BTF_NAMECHANGE:
-    btype->flags |= BTF_NAMECHANGE;
-    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "error278"));
-    test_clear_messages(u->faction);
-    name_cmd(u, ord); */
     test_teardown();
 }
 
@@ -1038,7 +1080,7 @@ static void test_name_ship(CuTest *tc) {
 
     ship_set_owner(uo);
     name_cmd(u, u->thisorder);
-    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "error12"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "not_ship_owner"));
     test_clear_messages(f);
 
     ship_set_owner(u);
@@ -1048,15 +1090,23 @@ static void test_name_ship(CuTest *tc) {
     ship_setname(u->ship, "Titanic");
     ship_set_owner(ux);
     name_cmd(u, u->thisorder);
-    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "error12"));
-    CuAssertStrEquals(tc, "Hodor", u->ship->name);
-
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "not_ship_owner"));
+    CuAssertStrEquals(tc, "Titanic", u->ship->name);
     test_clear_messages(f);
     free_order(u->thisorder);
+
+    ship_set_owner(u);
     u->thisorder = create_order(K_NAME, f->locale, LOC(f->locale, parameters[P_SHIP]));
     name_cmd(u, u->thisorder);
     CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "error84"));
-    CuAssertStrEquals(tc, "Hodor", u->ship->name);
+    CuAssertStrEquals(tc, "Titanic", u->ship->name);
+    free_order(u->thisorder);
+
+    leave_ship(u);
+    u->thisorder = create_order(K_NAME, f->locale, "%s Hodor", LOC(f->locale, parameters[P_SHIP]));
+    name_cmd(u, u->thisorder);
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "not_in_ship"));
+    CuAssertStrEquals(tc, "Titanic", uo->ship->name);
 
     test_teardown();
 }
@@ -1204,14 +1254,14 @@ static void test_ally_cmd_errors(CuTest *tc) {
     order *ord;
 
     test_setup();
-    mt_create_error(66);
+    mt_create_feedback("faction_not_found");
     u = test_create_unit(test_create_faction(), test_create_region(0, 0, NULL));
     fid = u->faction->no + 1;
     CuAssertPtrEquals(tc, NULL, findfaction(fid));
 
     ord = create_order(K_ALLY, u->faction->locale, itoa36(fid));
     ally_cmd(u, ord);
-    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "error66"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "faction_not_found"));
     free_order(ord);
 
     test_teardown();
@@ -1284,10 +1334,12 @@ static void test_name_cmd(CuTest *tc) {
     faction *f;
     alliance *al;
     order *ord;
+    char longname[NAMESIZE + 10];
+    memset(longname, 'x', sizeof(longname));
+    longname[NAMESIZE + 9] = 0;
 
     test_setup();
     u = test_create_unit(f = test_create_faction(), test_create_region(0, 0, NULL));
-    setalliance(f, al = makealliance(42, ""));
 
     ord = create_order(K_NAME, f->locale, "%s '  Ho\tdor  '", LOC(f->locale, parameters[P_UNIT]));
     name_cmd(u, ord);
@@ -1304,21 +1356,44 @@ static void test_name_cmd(CuTest *tc) {
     name_cmd(u, ord);
     CuAssertStrEquals(tc, "Hodor", u->ship->name);
     free_order(ord);
-    
+
     ord = create_order(K_NAME, f->locale, "%s '  Ho\tdor  '", LOC(f->locale, parameters[P_BUILDING]));
     u_set_building(u, test_create_building(u->region, NULL));
     name_cmd(u, ord);
     CuAssertStrEquals(tc, "Hodor", u->building->name);
     free_order(ord);
-    
+
     ord = create_order(K_NAME, f->locale, "%s '  Ho\tdor  '", LOC(f->locale, parameters[P_REGION]));
     name_cmd(u, ord);
     CuAssertStrEquals(tc, "Hodor", u->region->land->name);
     free_order(ord);
 
+    ord = create_order(K_NAME, f->locale, "Hodor Hodor");
+    CuAssertIntEquals(tc, 0, name_cmd(u, ord));
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "name_what"));
+    free_order(ord);
+
+    ord = create_order(K_NAME, f->locale, "%s '  Ho\tdor  '", LOC(f->locale, parameters[P_GROUP]));
+    name_cmd(u, ord);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "not_in_group"));
+    test_clear_messages(f);
+    join_group(u, "XXX");
+    CuAssertStrEquals(tc, "XXX", get_group(u)->name);
+    name_cmd(u, ord);
+    CuAssertStrEquals(tc, "Hodor", get_group(u)->name);
+    free_order(ord);
+
     ord = create_order(K_NAME, f->locale, "%s '  Ho\tdor  '", LOC(f->locale, parameters[P_ALLIANCE]));
     name_cmd(u, ord);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "not_in_alliance"));
+    setalliance(f, al = makealliance(42, ""));
+    name_cmd(u, ord);
     CuAssertStrEquals(tc, "Hodor", al->name);
+    free_order(ord);
+
+    ord = create_order(K_NAME, f->locale, "%s \"%s\"", LOC(f->locale, parameters[P_UNIT]), longname);
+    name_cmd(u, ord);
+    CuAssertIntEquals(tc, NAMESIZE - 1, strlen(u->_name));
     free_order(ord);
 
     test_teardown();
@@ -1329,16 +1404,136 @@ static void test_name_foreign_cmd(CuTest *tc) {
     faction *f;
     region *r;
     unit *u;
+    unit *ux;
+    ship *sh;
 
     test_setup();
+
     u = test_create_unit(f = test_create_faction(), r = test_create_region(0, 0, NULL));
+    ux = test_create_unit(test_create_faction(), r);
     b = test_create_building(u->region, NULL);
+    sh = test_create_ship(r, NULL);
+
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_UNIT]),
+        itoa36(ux->no));
+    name_cmd(u, u->thisorder);
+    CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_unit_seen"));
+    CuAssertStrEquals(tc, "Hodor", ux->_name);
+    test_clear_messages(f);
+    free_order(u->thisorder);
+
+    u_set_building(ux, b);
+    building_set_owner(ux);
     u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
         LOC(f->locale, parameters[P_FOREIGN]),
         LOC(f->locale, parameters[P_BUILDING]),
         itoa36(b->no));
     name_cmd(u, u->thisorder);
     CuAssertStrEquals(tc, "Hodor", b->name);
+    CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_building_seen"));
+    test_clear_messages(f);
+
+    building_setname(b, "Home");
+
+    name_cmd(u, u->thisorder);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "building_renamed"));
+    CuAssertStrEquals(tc, "Home", b->name);
+    test_clear_messages(f);
+    free_order(u->thisorder);
+
+    u_set_ship(ux, sh);
+    ship_set_owner(ux);
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_SHIP]),
+        itoa36(sh->no));
+    name_cmd(u, u->thisorder);
+    CuAssertStrEquals(tc, "Hodor", sh->name);
+    CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_ship_seen"));
+    test_clear_messages(f);
+    free_order(u->thisorder);
+
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_REGION]),
+        itoa36(b->no));
+    region_setname(r, "Region");
+    name_cmd(u, u->thisorder);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "foreign_not_allowed"));
+    CuAssertStrEquals(tc, "Region", region_getname(r));
+    free_order(u->thisorder);
+
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_UNIT]),
+        itoa36(u->no % 667 + 1));
+    name_cmd(u, u->thisorder);
+    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "feedback_unit_not_found"));
+    CuAssertStrEquals(tc, "Region", region_getname(r));
+
+    test_teardown();
+}
+
+static void test_name_foreign_unseen(CuTest *tc) {
+    building *b;
+    faction *f;
+    region *r;
+    unit *u;
+    unit *ux;
+    ship *sh;
+
+    test_setup();
+    u = test_create_unit(f = test_create_faction(), r = test_create_region(0, 0, NULL));
+    set_level(u, SK_STEALTH, 1);
+    ux = test_create_unit(test_create_faction(), r);
+    b = test_create_building(u->region, NULL);
+    sh = test_create_ship(r, NULL);
+
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_UNIT]),
+        itoa36(ux->no));
+    name_cmd(u, u->thisorder);
+    CuAssertStrEquals(tc, "Hodor", ux->_name);
+    CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_unit_notseen"));
+    test_clear_messages(f);
+    free_order(u->thisorder);
+
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_FACTION]),
+        itoa36(ux->faction->no));
+    name_cmd(u, u->thisorder);
+    CuAssertStrEquals(tc, "Hodor", ux->faction->name);
+    CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_faction_notseen"));
+    test_clear_messages(f);
+    free_order(u->thisorder);
+
+    u_set_building(ux, b);
+    building_set_owner(ux);
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_BUILDING]),
+        itoa36(b->no));
+    name_cmd(u, u->thisorder);
+    CuAssertStrEquals(tc, "Hodor", b->name);
+    CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_building_notseen"));
+    test_clear_messages(f);
+    free_order(u->thisorder);
+
+    u_set_ship(ux, sh);
+    ship_set_owner(ux);
+    u->thisorder = create_order(K_NAME, f->locale, "%s %s %s Hodor",
+        LOC(f->locale, parameters[P_FOREIGN]),
+        LOC(f->locale, parameters[P_SHIP]),
+        itoa36(sh->no));
+    name_cmd(u, u->thisorder);
+    CuAssertStrEquals(tc, "Hodor", sh->name);
+    CuAssertPtrNotNull(tc, test_find_messagetype(ux->faction->msgs, "renamed_ship_notseen"));
+    test_clear_messages(f);
+
     test_teardown();
 }
 
@@ -1436,7 +1631,7 @@ static unit * setup_mail_cmd(void) {
     faction *f;
     
     test_setup();
-    mt_create_error(66);
+    mt_create_feedback("faction_not_found");
     mt_create_error(30);
     mt_create_va(mt_new("regionmessage", NULL), "region:region", "sender:unit", "string:string", MT_NEW_END);
     mt_create_va(mt_new("unitmessage", NULL), "region:region", "sender:unit", "string:string", "unit:unit", MT_NEW_END);
@@ -1527,7 +1722,7 @@ static void test_mail_faction_no_target(CuTest *tc) {
     ord = create_order(K_MAIL, f->locale, "%s %s", LOC(f->locale, parameters[P_FACTION]), itoa36(f->no+1));
     mail_cmd(u, ord);
     CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "regionmessage"));
-    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "error66"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "faction_not_found"));
     free_order(ord);
     test_teardown();
 }
@@ -2041,7 +2236,7 @@ static void test_quit(CuTest *tc) {
 #ifdef QUIT_WITH_TRANSFER
 /**
  * Gifting units to another faction upon voluntary death (QUIT).
- */ 
+ */
 static void test_quit_transfer(CuTest *tc) {
     faction *f1, *f2;
     unit *u1, *u2;
@@ -2266,6 +2461,7 @@ CuSuite *get_laws_suite(void)
     SUITE_ADD_TEST(suite, test_ally_cmd);
     SUITE_ADD_TEST(suite, test_name_cmd);
     SUITE_ADD_TEST(suite, test_name_foreign_cmd);
+    SUITE_ADD_TEST(suite, test_name_foreign_unseen);
     SUITE_ADD_TEST(suite, test_banner_cmd);
     SUITE_ADD_TEST(suite, test_email_cmd);
     SUITE_ADD_TEST(suite, test_name_cmd_2274);
@@ -2285,8 +2481,7 @@ CuSuite *get_laws_suite(void)
     SUITE_ADD_TEST(suite, test_long_order_hungry);
     SUITE_ADD_TEST(suite, test_new_building_can_be_renamed);
     SUITE_ADD_TEST(suite, test_password_cmd);
-    SUITE_ADD_TEST(suite, test_rename_building);
-    SUITE_ADD_TEST(suite, test_rename_building_twice);
+    SUITE_ADD_TEST(suite, test_renamed_thing);
     SUITE_ADD_TEST(suite, test_fishing_feeds_2_people);
     SUITE_ADD_TEST(suite, test_fishing_does_not_give_goblins_money);
     SUITE_ADD_TEST(suite, test_fishing_gets_reset);

--- a/src/renumber.c
+++ b/src/renumber.c
@@ -162,7 +162,7 @@ int renumber_cmd(unit * u, order * ord)
     case P_BUILDING:
     case P_GEBAEUDE:
         if (!u->building) {
-            cmistake(u, ord, 145, MSG_EVENT);
+            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "not_in_building", ""));
             break;
         }
         if (building_owner(u->building) != u) {

--- a/src/spy.c
+++ b/src/spy.c
@@ -283,7 +283,7 @@ int setstealth_cmd(unit * u, struct order *ord)
                     else {
                         struct faction *f = findfaction(nr);
                         if (f == NULL || !can_set_factionstealth(u, f)) {
-                            cmistake(u, ord, 66, MSG_EVENT);
+                            ADDMSG(&u->faction->msgs, msg_feedback(u, ord, "faction_not_found", ""));
                             break;
                         }
                         else {


### PR DESCRIPTION
Fix für https://bugs.eressea.de/view.php?id=2747 und mehr.

Habe einige Tests hinzugefügt und die ganzen Fälle vereinheitlicht. War die Hölle ohne Polymorphie. Ist immer noch hässlich, aber besser kriege ich es nicht hin.

Sichtbare Änderungen: 
- BENENNE FREMDE BURG funktioniert jetzt.
- Neue Gebäude heißen jetzt wieder Sägewerk abc statt nur Sägewerk. BENENNE FREMD funktioniert bei beiden Arten von Namen. 
- BENNENE GRUPPE ging schon immer, war ohne Dokumentation, ist aber sinnvoll. Würde ich in die Anleitung übernehmen.
- BESCHREIBE PARTEI ist jetzt Synonym für BANNER
- Ein paar verbesserte Fehlermeldungen.
