### PR TITLE
Update rustyhalberd.xml

### DIFF
--- a/res/core/weapons/rustyhalberd.xml
+++ b/res/core/weapons/rustyhalberd.xml
@@ -5,9 +5,9 @@
   <item weight="200" score="20">
     <construction skill="weaponsmithing" minskill="3">
       <requirement type="iron" quantity="1"/>
-      <requirement type="log" quantity="1"/>
+      <requirement type="log" quantity="2"/>
     </construction>
-    <weapon cut="true" skill="polearm" offmod="-2" defmod="-1">
+    <weapon cut="true" skill="polearm" offmod="-2" defmod="+1">
       <damage type="rider" value="2d6"/>
       <damage type="footman" value="2d6"/>
 


### PR DESCRIPTION
Wood cost adjusted to normal halberd. OB/DB adjusted to all other rusty weapons (-1/-1 compared to normal variant). Halberd -1/+2 -> rusty halberd now -2/+1