### PR TITLE
temporary units cannot recruit when guarded

### DIFF
--- a/scripts/tests/recruit.lua
+++ b/scripts/tests/recruit.lua
@@ -45,7 +45,7 @@ function test_bug_1795_demons()
   assert_equal(peasants, r:get_resource("peasant"))
 end
 
-function skip_test_guarded_temp_cannot_recruit()
+function test_guarded_temp_cannot_recruit()
     local r = region.create(0, 0, 'plain')
 
     local f1 = faction.create('human')

--- a/scripts/tests/recruit.lua
+++ b/scripts/tests/recruit.lua
@@ -44,3 +44,36 @@ function test_bug_1795_demons()
   assert_equal(limit+1, u1.number, u1.number .. "!=" .. (limit+1))
   assert_equal(peasants, r:get_resource("peasant"))
 end
+
+function skip_test_guarded_temp_cannot_recruit()
+    local r = region.create(0, 0, 'plain')
+
+    local f1 = faction.create('human')
+    local f2 = faction.create('human')
+    local u1 = unit.create(f1, r, 1)
+    local u2 = unit.create(f2, r, 1)
+
+    r.peasants = 1000
+
+    u2:add_item("sword", 1)
+    u2:set_skill("melee", 1)
+    u2.guard = true
+
+    u1:add_item("money", 100)
+    u1:add_order("MACHE TEMP x")
+    u1:add_order("REKRUTIERE 1")
+    u1:add_order("ENDE")
+    u1:add_order("MACHE TEMP y")
+    u1:add_order("ENDE")
+    u1:add_order("GIB TEMP y 1 PERSON")
+    process_orders()
+
+    local count = 0
+    local zero = 0
+    for u in f1.units do
+      if u.number == 0 then zero = zero + 1 end
+      count = count + 1
+    end
+    assert_equal(0, zero)
+    assert_equal(1, count)
+end

--- a/src/laws.c
+++ b/src/laws.c
@@ -2855,7 +2855,7 @@ int checkunitnumber(const faction * f, int add)
     return 0;
 }
 
-void maketemp_cmd(unit *u, order **olist) 
+static void maketemp_cmd(unit *u, order **olist) 
 {
     order *makeord;
     int err = checkunitnumber(u->faction, 1);
@@ -4039,7 +4039,7 @@ typedef enum cansee_t {
 static enum cansee_t cansee_ex(const unit *u, const region *r, const unit *target, int stealth, int rings)
 {
     enum cansee_t result = CANSEE_HIDDEN;
-    if (rings >= target->number) {
+    if (rings > 0 && rings >= target->number) {
         const resource_type *rtype = get_resourcetype(R_AMULET_OF_TRUE_SEEING);
         if (rtype) {
             int amulet = i_get(u->items, rtype->itype);
@@ -4139,14 +4139,14 @@ bool cansee(const faction *f, const region *r, const unit *u, int modifier)
         }
     }
     if (is_exposed(u)) {
-        /* obviosuly visibile, we only need a viewer in the region */
+        /* obviously visible, we only need a viewer in the region */
         return true;
     }
 
     rings = invisible(u, NULL);
     stealth = eff_stealth(u, r) - modifier;
 
-    if (rings < u->number && stealth <= 0) {
+    if (rings > 0 && rings < u->number && stealth <= 0) {
         return true;
     }
 

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1999,6 +1999,23 @@ static void test_cansee_sphere(CuTest *tc) {
     test_teardown();
 }
 
+static void test_cansee_temp(CuTest* tc) {
+    unit* u, * u2;
+
+    test_setup();
+    u = test_create_unit(test_create_faction(), test_create_region(0, 0, NULL));
+    u2 = test_create_unit(test_create_faction(), u->region);
+
+    u->orders = create_order(K_MAKETEMP, u->faction->locale, "1");
+    new_units();
+    u2 = u2->next;
+
+    CuAssertPtrNotNull(tc, u2);
+    CuAssertTrue(tc, cansee(u->faction, u->region, u2, 0));
+
+    test_teardown();
+}
+
 /**
  * Hidden monsters are seen in oceans if they are big enough.
  */
@@ -2509,6 +2526,7 @@ CuSuite *get_laws_suite(void)
     SUITE_ADD_TEST(suite, test_cansee_ring);
     SUITE_ADD_TEST(suite, test_cansee_sphere);
     SUITE_ADD_TEST(suite, test_cansee_monsters);
+    SUITE_ADD_TEST(suite, test_cansee_temp);
     SUITE_ADD_TEST(suite, test_nmr_timeout);
     SUITE_ADD_TEST(suite, test_long_orders);
     SUITE_ADD_TEST(suite, test_long_order_on_ocean);

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -865,7 +865,7 @@ static void test_newbie_warning(CuTest *tc) {
 }
 
 static void test_visible_unit(CuTest* tc) {
-    unit* u, *u2;
+    unit* u;
     faction* f;
     ship* sh;
     building* b;
@@ -878,7 +878,7 @@ static void test_visible_unit(CuTest* tc) {
 
     /* visibility on land */
     u = test_create_unit(test_create_faction_ex(rc, NULL), test_create_plain(0, 0));
-    u2 = test_create_unit(f, u->region);
+    test_create_unit(f, u->region);
     CuAssertTrue(tc, cansee(f, u->region, u, 0));
     CuAssertTrue(tc, visible_unit(u, f, 0, seen_unit));
     CuAssertTrue(tc, visible_unit(u, f, 0, seen_spell));
@@ -899,7 +899,7 @@ static void test_visible_unit(CuTest* tc) {
 
     /* visibility of stealthed units in oceans */
     u = test_create_unit(u->faction, test_create_ocean(0, 1));
-    u2 = test_create_unit(f, u->region);
+    test_create_unit(f, u->region);
     set_level(u, SK_STEALTH, 2);
     CuAssertTrue(tc, !visible_unit(u, f, 0, seen_none));
     CuAssertTrue(tc, !visible_unit(u, f, 0, seen_neighbour));

--- a/src/reports.test.c
+++ b/src/reports.test.c
@@ -865,7 +865,7 @@ static void test_newbie_warning(CuTest *tc) {
 }
 
 static void test_visible_unit(CuTest* tc) {
-    unit* u;
+    unit* u, *u2;
     faction* f;
     ship* sh;
     building* b;
@@ -877,7 +877,8 @@ static void test_visible_unit(CuTest* tc) {
     rc->flags |= RCF_UNARMEDGUARD;
 
     /* visibility on land */
-    u = test_create_unit(test_create_faction_ex(rc, NULL), test_create_region(0, 0, NULL));
+    u = test_create_unit(test_create_faction_ex(rc, NULL), test_create_plain(0, 0));
+    u2 = test_create_unit(f, u->region);
     CuAssertTrue(tc, cansee(f, u->region, u, 0));
     CuAssertTrue(tc, visible_unit(u, f, 0, seen_unit));
     CuAssertTrue(tc, visible_unit(u, f, 0, seen_spell));
@@ -898,6 +899,7 @@ static void test_visible_unit(CuTest* tc) {
 
     /* visibility of stealthed units in oceans */
     u = test_create_unit(u->faction, test_create_ocean(0, 1));
+    u2 = test_create_unit(f, u->region);
     set_level(u, SK_STEALTH, 2);
     CuAssertTrue(tc, !visible_unit(u, f, 0, seen_none));
     CuAssertTrue(tc, !visible_unit(u, f, 0, seen_neighbour));


### PR DESCRIPTION
Original fix courtesy of @stm2 