### PR TITLE
Revert "fix unused variable warning"

### DIFF
--- a/res/core/messages.xml
+++ b/res/core/messages.xml
@@ -775,6 +775,11 @@
       <arg name="sender" type="unit"/>
     </type>
   </message>
+  <message name="maintenance_nowork" section="events">
+    <type>
+      <arg name="building" type="building"/>
+    </type>
+  </message>
   <message name="icastle_dissolve" section="events">
     <type>
       <arg name="building" type="building"/>
@@ -5421,6 +5426,11 @@
   <message name="maintenancefail" section="errors">
     <type>
       <arg name="unit" type="unit"/>
+      <arg name="building" type="building"/>
+    </type>
+  </message>
+  <message name="maintenance_noowner" section="errors">
+    <type>
       <arg name="building" type="building"/>
     </type>
   </message>

--- a/res/translations/messages.de.po
+++ b/res/translations/messages.de.po
@@ -245,6 +245,9 @@ msgstr "\"$unit($mage) ruft das Feuer der Sonne auf $region($region) hinab. Die 
 msgid "spellfail_pump"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - $unit($target) wusste trotz intensivem Verhör nichts über $region($tregion) zu berichten.\""
 
+msgid "maintenance_nowork"
+msgstr "\"$building($building) hat diese Woche nicht funktioniert, da zu Beginn der Woche der Unterhalt nicht gezahlt werden konnte.\""
+
 msgid "error_spell_on_flying_ship"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Es ist zu gefährlich, diesen Zauber auf das fliegende Schiff $ship($ship) zu legen.\""
 
@@ -2074,6 +2077,9 @@ msgstr "\"Beim Vulkanausbruch in $region($region) sterben $int($dead) Personen i
 
 msgid "curseinfo::warmth_1"
 msgstr "\"$int($number) $if($eq($number,1), \"Person\", \"Personen\") von $unit($unit) $if($eq($number,1), \"fühlt\", \"fühlen\") sich vor Kälte geschützt. ($int36($id))\""
+
+msgid "maintenance_noowner"
+msgstr "\"Der Unterhalt von $building($building) konnte nicht gezahlt werden, das Gebäude war diese Woche nicht funktionstüchtig.\""
 
 msgid "error27"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Die Anzahl zu verkaufender Produkte fehlt.\""

--- a/res/translations/messages.en.po
+++ b/res/translations/messages.en.po
@@ -245,6 +245,9 @@ msgstr "\"$unit($mage) calls the torching power of the sun upon $region($region)
 msgid "spellfail_pump"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - Despite intense questioning, $unit($target) did not have anything to tell about $region($tregion).\""
 
+msgid "maintenance_nowork"
+msgstr "\"$building($building) was nonfunctional because upkeep could not be paid at the beginning of the week.\""
+
 msgid "error_spell_on_flying_ship"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - It is far too dangerous to put this spell on the flying ship $ship($ship).\""
 
@@ -2074,6 +2077,9 @@ msgstr "\"$int($dead) people in $unit($unit) perish when the volcano in $region(
 
 msgid "curseinfo::warmth_1"
 msgstr "\"$int($number) $if($eq($number,1), \"member\", \"members\") of $unit($unit) $if($eq($number,1), \"is\", \"are\") protected from the cold. ($int36($id))\""
+
+msgid "maintenance_noowner"
+msgstr "\"The upkeep for $building($building) was not paid, the building was not operational this week.\""
 
 msgid "error27"
 msgstr "\"$unit($unit) in $region($region): '$order($command)' - The amount of items for sale is missing.\""

--- a/src/economy.test.c
+++ b/src/economy.test.c
@@ -466,6 +466,8 @@ static void setup_economy(void) {
     mt_create_va(mt_new("recruit", NULL), "unit:unit", "region:region", "amount:int", "want:int", MT_NEW_END);
     mt_create_va(mt_new("maintenance", NULL), "unit:unit", "building:building", MT_NEW_END);
     mt_create_va(mt_new("maintenancefail", NULL), "unit:unit", "building:building", MT_NEW_END);
+    mt_create_va(mt_new("maintenance_nowork", NULL), "building:building", MT_NEW_END);
+    mt_create_va(mt_new("maintenance_noowner", NULL), "building:building", MT_NEW_END);
 }
 
 /** 
@@ -509,7 +511,7 @@ static void test_maintain_buildings(CuTest *tc) {
     maintain_buildings(r);
     CuAssertIntEquals(tc, BLD_UNMAINTAINED, fval(b, BLD_UNMAINTAINED));
     CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "maintenancefail"));
-    CuAssertPtrEquals(tc, NULL, r->msgs);
+    CuAssertPtrNotNull(tc, test_find_messagetype(r->msgs, "maintenance_nowork"));
     test_clear_messagelist(&f->msgs);
     test_clear_messagelist(&r->msgs);
     
@@ -520,6 +522,7 @@ static void test_maintain_buildings(CuTest *tc) {
     CuAssertIntEquals(tc, 0, fval(b, BLD_UNMAINTAINED));
     CuAssertIntEquals(tc, 0, i_get(u->items, itype));
     CuAssertPtrEquals(tc, NULL, r->msgs);
+    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "maintenance_nowork"));
     CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "maintenance"));
     test_clear_messagelist(&f->msgs);
 
@@ -529,7 +532,7 @@ static void test_maintain_buildings(CuTest *tc) {
     maintain_buildings(r);
     CuAssertIntEquals(tc, BLD_UNMAINTAINED, fval(b, BLD_UNMAINTAINED));
     CuAssertPtrEquals(tc, NULL, f->msgs);
-    CuAssertPtrEquals(tc, NULL, r->msgs);
+    CuAssertPtrNotNull(tc, test_find_messagetype(r->msgs, "maintenance_noowner"));
     test_clear_messagelist(&r->msgs);
 
     test_teardown();

--- a/src/economy.test.c
+++ b/src/economy.test.c
@@ -517,12 +517,22 @@ static void test_maintain_buildings(CuTest *tc) {
     
     /* we can afford to pay: */
     i_change(&u->items, itype, 100);
+    /* but we don't want to: */
+    b->flags = BLD_DONTPAY;
+    maintain_buildings(r);
+    CuAssertIntEquals(tc, BLD_UNMAINTAINED, fval(b, BLD_UNMAINTAINED));
+    CuAssertIntEquals(tc, 100, i_get(u->items, itype));
+    CuAssertPtrNotNull(tc, test_find_messagetype(r->msgs, "maintenance_nowork"));
+    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "maintenance"));
+    test_clear_messagelist(&f->msgs);
+    test_clear_messagelist(&r->msgs);
+
+    /* if we want to, items get used: */
     b->flags = 0;
     maintain_buildings(r);
     CuAssertIntEquals(tc, 0, fval(b, BLD_UNMAINTAINED));
     CuAssertIntEquals(tc, 0, i_get(u->items, itype));
-    CuAssertPtrEquals(tc, NULL, r->msgs);
-    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f->msgs, "maintenance_nowork"));
+    CuAssertPtrEquals(tc, NULL, test_find_messagetype(r->msgs, "maintenance_nowork"));
     CuAssertPtrNotNull(tc, test_find_messagetype(f->msgs, "maintenance"));
     test_clear_messagelist(&f->msgs);
 


### PR DESCRIPTION
This reverts commit f58d8786b7be7dea5740ea97685e332886cd07fe.

Revert "Regionsmeldungen für Gebäudeunterhalt entfernt."

This reverts commit 866bcf30baaef7f1709c212ca4586e03f32ba8f8.