### PR TITLE
orks should learn weapon skills with normal speed

### DIFF
--- a/res/eressea/races.xml
+++ b/res/eressea/races.xml
@@ -1193,6 +1193,12 @@ giveunit="yes" getitem="yes" recruitethereal="yes" equipment="yes">
     <skill name="cartmaking" modifier="-1"/>
     <skill name="taxation" modifier="1"/>
     <skill name="unarmed" modifier="-99"/>
+    <skill name="bow" speed="0"/>
+    <skill name="catapult" speed="0"/>
+    <skill name="crossbow" speed="0"/>
+    <skill name="melee" speed="0"/>
+    <skill name="polearm" speed="0"/>
+    <skill name="stamina" speed="0"/>
     <attack type="1" damage="1d5"/>
     <familiar race="goblin"/>
     <familiar race="ghost"/>

--- a/src/exparse.c
+++ b/src/exparse.c
@@ -1070,7 +1070,8 @@ static void start_races(parseinfo *pi, const XML_Char *el, const XML_Char **attr
     else if (xml_strequal(el, "skill")) {
         const XML_Char *name = NULL;
         int i, speed = 0, mod = 0;
-
+        bool speed_is_set = false;
+        assert(rc);
         for (i = 0; attr[i]; i += 2) {
             const XML_Char *key = attr[i], *val = attr[i + 1];
             if (xml_strequal(key, "name")) {
@@ -1081,6 +1082,7 @@ static void start_races(parseinfo *pi, const XML_Char *el, const XML_Char **attr
             }
             else if (xml_strequal(key, "speed")) {
                 speed = xml_int(val);
+                speed_is_set = true;
             }
             else {
                 handle_bad_input(pi, el, key);
@@ -1090,7 +1092,7 @@ static void start_races(parseinfo *pi, const XML_Char *el, const XML_Char **attr
             skill_t sk = findskill(name);
             if (sk != NOSKILL) {
                 rc->bonus[sk] = (char)mod;
-                if (speed != 0) {
+                if (speed_is_set) {
                     set_study_speed(rc, sk, speed);
                 }
             }


### PR DESCRIPTION
Behebt den Fehler, dass Orks Waffentalente (Bogen, Katapult, Armbrust, Hiebwaffen, Stangenwaffen, Ausdauer) genau so langsam lernen wie andere.