### PR TITLE
lighthouse reporting range respects multiple units.

### DIFF
--- a/src/reports.c
+++ b/src/reports.c
@@ -1423,7 +1423,7 @@ void prepare_report(report_context *ctx, faction *f, const char *password)
         for (r = ctx->first; r != ctx->last; r = r->next) {
             unit *u;
             building *b;
-            int br = 0, c = 0, range = 0;
+            int c = 0, range = 0;
             if (fval(r, RF_OBSERVER)) {
                 int skill = get_observer(r, f);
                 if (skill >= 0) {
@@ -1457,11 +1457,10 @@ void prepare_report(report_context *ctx, faction *f, const char *password)
                         break;
                     }
                 }
-                if (range == 0 && u->building && u->building->type == bt_lighthouse) {
+                if (u->building && u->building->type == bt_lighthouse) {
                     if (u->building && b != u->building) {
                         b = u->building;
                         c = buildingcapacity(b);
-                        br = 0;
                     }
                     if (rule_lighthouse_units) {
                         --c;
@@ -1471,12 +1470,9 @@ void prepare_report(report_context *ctx, faction *f, const char *password)
                     }
                     if (u->faction == f && c >= 0) {
                         /* unit is one of ours, and inside the current lighthouse */
-                        if (br == 0) {
-                            /* lazy-calculate the range */
-                            br = lighthouse_view_distance(b, u);
-                            if (br > range) {
-                                range = br;
-                            }
+                        int br = lighthouse_view_distance(b, u);
+                        if (br > range) {
+                            range = br;
                         }
                     }
                 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -200,7 +200,7 @@ struct faction* test_create_faction(void) {
 
 struct unit *test_create_unit(struct faction *f, struct region *r)
 {
-    const struct race * rc = f ? f->race : 0;
+    const struct race * rc = f ? f->race : NULL;
     if (!rc) rc = rc_get_or_create("human");
     if (!f) f = test_create_faction_ex(rc, NULL);
     if (!r) r = test_create_plain(0, 0);
@@ -250,7 +250,7 @@ void test_reset(void)
 static void test_reset_full(void) {
     int i;
     turn = 1;
-    default_locale = 0;
+    default_locale = NULL;
 
     if (errno) {
         int error = errno;
@@ -264,7 +264,6 @@ static void test_reset_full(void) {
     free_resources();
     free_functions();
     free_config();
-    default_locale = 0;
     calendar_cleanup();
     creport_cleanup();
     report_cleanup();


### PR DESCRIPTION
Fix range of lighthouses when more faction has more than one eligible unit