### PR TITLE
Adding missing library and call to config to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ install all of them:
 
     sudo apt-get install git cmake gcc make luarocks \
         liblua5.2-dev libtolua-dev libncurses5-dev libsqlite3-dev \
-        libcjson-dev libiniparser-dev libexpat1-dev
+        libcjson-dev libiniparser-dev libexpat1-dev libutf8proc-dev
 
 ## How to check out and build the Eressea server
 
@@ -19,9 +19,10 @@ This repository relies heavily on the use of submodules, and it pulls in
 most of the code from those. The build system being used is CMake.
 Here's how you clone and build the source on Linux or macOS:
 
-    git clone --recursive git://github.com/eressea/server.git source
+    git clone --recursive https://github.com/eressea/server.git source
     cd source
     git submodule update --init
+    ./configure
     s/build
 
 If you got this far and all went well, you have built the server, and


### PR DESCRIPTION
I tried to compile the code as described and there is one library missing:

`-- Found Curses: /usr/lib/x86_64-linux-gnu/libncursesw.so  
-- Found EXPAT: /usr/lib/x86_64-linux-gnu/libexpat.so (found version "2.5.0") 
-- Found Lua: /usr/lib/x86_64-linux-gnu/liblua5.2.so;/usr/lib/x86_64-linux-gnu/libm.so (found suitable version "5.2.4", minimum required is "5.2") 
CMake Error at /usr/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Utf8Proc (missing: UTF8PROC_LIBRARY UTF8PROC_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindUtf8Proc.cmake:49 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:33 (find_package)
`

I added the libutf8proc-dev library to the description and also added a configure call to the procedure. Furthermore, I changed git to https protocol, so non-contributors can quickly check the code. 