### PR TITLE
hotfix for missing loot divisor

### DIFF
--- a/conf/e2/config.json
+++ b/conf/e2/config.json
@@ -23,6 +23,7 @@
 		"rules.ship.overload.damage.max": 0.0,
 		"rules.reserve.twophase": true,
 		"rules.give.max_men": -1,
+		"rules.items.loot_divisor": 2,
 		"rules.check_overload": false,
 		"rules.limit.faction": 2500,
 		"rules.maxskills.magic": 5,


### PR DESCRIPTION
Resolves https://bugs.eressea.de/view.php?id=2999