### PR TITLE
Hotfix: Schattendämonen und Schattenmeister haben zu hohe Tarnung.

### DIFF
--- a/src/kernel/gamedata.h
+++ b/src/kernel/gamedata.h
@@ -54,8 +54,9 @@
 #define FIX_RESOURCES_VERSION 376 /* badly made rawmaterials, bug 2898 */
 #define REMOVE_FACTION_AGE_VERSION 377 /* save start_turn, not age, bug 2878 */
 #define FORBIDDEN_LAND_VERSION 378 /* forbidden regions (walls) do not store land info */
+#define FIX_SHADOWS_VERSION 379 /* shadowdemon/-master skills, bug 3011 */
 
-#define RELEASE_VERSION FORBIDDEN_LAND_VERSION /* use for new datafiles */
+#define RELEASE_VERSION FIX_SHADOWS_VERSION /* use for new datafiles */
 #define MIN_VERSION UIDHASH_VERSION      /* minimal datafile we support */
 #define MAX_VERSION RELEASE_VERSION /* change this if we can need to read the future datafile, and we can do so */
 

--- a/src/kernel/save.c
+++ b/src/kernel/save.c
@@ -1296,6 +1296,27 @@ static int cb_sb_maxlevel(spellbook_entry *sbe, void *cbdata) {
     return 0;
 }
 
+void fix_shadows(void)
+{
+    region *r;
+    const race *rc_demon = get_race(RC_SHADOW);
+    const race *rc_lord = get_race(RC_SHADOWLORD);
+    for (r = regions; r; r = r->next) {
+        unit *u;
+        for (u = r->units; u; u = u->next) {
+            const race *rc = u_race(u);
+            if (rc == rc_demon) {
+                int level = get_level(u, SK_STEALTH);
+                set_level(u, SK_STEALTH, level / 2);
+            } 
+            else if (rc == rc_lord) {
+                int level = get_level(u, SK_STEALTH);
+                set_level(u, SK_STEALTH, level - 1);
+            }
+        }
+    }
+}
+
 int readgame(const char *filename)
 {
     int n = -2, stream_version;
@@ -1331,6 +1352,9 @@ int readgame(const char *filename)
             log_debug("data in %s created with build %d.", filename, build);
         }
         n = read_game(&gdata);
+        if (gdata.version < FIX_SHADOWS_VERSION) {
+            fix_shadows();
+        }
         binstore_done(&store);
         fstream_done(&strm);
     }

--- a/src/kernel/save.h
+++ b/src/kernel/save.h
@@ -45,3 +45,5 @@ int read_game(struct gamedata *data);
 /* test-only functions that give access to internal implementation details (BAD) */
 void _test_write_password(struct gamedata *data, const struct faction *f);
 void _test_read_password(struct gamedata *data, struct faction *f);
+
+void fix_shadows(void);

--- a/src/kernel/save.test.c
+++ b/src/kernel/save.test.c
@@ -475,6 +475,22 @@ static void test_version_no(CuTest *tc) {
     CuAssertIntEquals(tc, 0x10203, version_no("1.2.3-what.is.42"));
 }
 
+static void test_fix_shadows(CuTest *tc) {
+    unit *u1, *u2;
+
+    test_setup();
+    u1 = test_create_unit(test_create_faction(), test_create_plain(0, 0));
+    u_setrace(u1, test_create_race("shadowdemon"));
+    test_set_skill(u1, SK_STEALTH, 16, 1);
+    u2 = test_create_unit(test_create_faction(), test_create_plain(1, 0));
+    u_setrace(u2, test_create_race("shadowmaster"));
+    test_set_skill(u2, SK_STEALTH, 16, 1);
+    fix_shadows();
+    CuAssertIntEquals(tc, 8, get_level(u1, SK_STEALTH));
+    CuAssertIntEquals(tc, 15, get_level(u2, SK_STEALTH));
+    test_teardown();
+}
+
 CuSuite *get_save_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -492,6 +508,7 @@ CuSuite *get_save_suite(void)
     SUITE_ADD_TEST(suite, test_read_password);
     SUITE_ADD_TEST(suite, test_read_password_external);
     SUITE_ADD_TEST(suite, test_version_no);
+    SUITE_ADD_TEST(suite, test_fix_shadows);
 
     return suite;
 }

--- a/src/spells.c
+++ b/src/spells.c
@@ -2948,7 +2948,7 @@ static int sp_plague(castorder * co)
  * Flag:
  *  (SPELLLEVEL)
  */
-static int sp_summonshadow(castorder * co)
+int sp_summonshadow(castorder * co)
 {
     region *r = co_get_region(co);
     unit *caster = co_get_caster(co);
@@ -2960,7 +2960,7 @@ static int sp_summonshadow(castorder * co)
     u = create_unit(r, caster->faction, number, get_race(RC_SHADOW), 0, NULL, caster);
 
     /* Bekommen Tarnung = (Magie+Tarnung)/2 und Wahrnehmung 1. */
-    val = get_level(caster, SK_MAGIC) + get_level(caster, SK_STEALTH);
+    val = (get_level(caster, SK_MAGIC) + get_level(caster, SK_STEALTH)) / 2;
 
     set_level(u, SK_STEALTH, val);
     set_level(u, SK_PERCEPTION, 1);

--- a/src/spells.c
+++ b/src/spells.c
@@ -2948,7 +2948,7 @@ static int sp_plague(castorder * co)
  * Flag:
  *  (SPELLLEVEL)
  */
-int sp_summonshadow(castorder * co)
+int sp_shadowdemons(castorder * co)
 {
     region *r = co_get_region(co);
     unit *caster = co_get_caster(co);
@@ -2979,7 +2979,7 @@ int sp_summonshadow(castorder * co)
  * Wirkung:
  *  Diese hoeheren Schattendaemonen sind erheblich gefaehrlicher als die
  *  einfachen Schattendaemonen.  Sie haben Tarnung entsprechend dem
- *  Magietalent des Beschwoerer-1 und Wahrnehmung 5, 75 HP,
+ *  Magietalent des Beschwoerers-1 und Wahrnehmung 5, 75 HP,
  *  Ruestungsschutz 4, Attacke-Bonus 11 und Verteidigungsbonus 13, machen
  *  bei einem Treffer 2d4 Schaden, entziehen einen Staerkepunkt und
  *  entziehen 5 Talenttage in einem zufaelligen Talent.
@@ -2988,7 +2988,7 @@ int sp_summonshadow(castorder * co)
  * Flag:
  *  (SPELLLEVEL)
  * */
-static int sp_summonshadowlords(castorder * co)
+int sp_shadowlords(castorder * co)
 {
     unit *u;
     region *r = co_get_region(co);
@@ -3001,7 +3001,7 @@ static int sp_summonshadowlords(castorder * co)
         NULL, caster);
 
     /* Bekommen Tarnung = Magie und Wahrnehmung 5. */
-    set_level(u, SK_STEALTH, get_level(caster, SK_MAGIC));
+    set_level(u, SK_STEALTH, get_level(caster, SK_MAGIC) - 1);
     set_level(u, SK_PERCEPTION, 5);
 
     ADDMSG(&caster->faction->msgs, msg_message("summon_effect", "mage amount race",
@@ -6209,7 +6209,7 @@ static spelldata spell_functions[] = {
     { "firewall", sp_firewall, patzer_peasantmob },
     { "plague", sp_plague, patzer_peasantmob },
     { "chaosrow", sp_chaosrow, 0 },
-    { "summonshadow", sp_summonshadow, patzer_peasantmob },
+    { "summonshadow", sp_shadowdemons, patzer_peasantmob },
     { "undeadhero", sp_undeadhero, 0 },
     { "auraleak", sp_auraleak, 0 },
     { "draigfumbleshield", sp_fumbleshield, 0 },
@@ -6218,7 +6218,7 @@ static spelldata spell_functions[] = {
     { "unholypower", sp_unholypower, 0 },
     { "deathcloud", sp_deathcloud, patzer_deathcloud },
     { "summondragon", sp_summondragon, patzer_peasantmob },
-    { "summonshadowlords", sp_summonshadowlords, patzer_peasantmob },
+    { "summonshadowlords", sp_shadowlords, patzer_peasantmob },
     { "chaossuction", sp_chaossuction, patzer_peasantmob },
     /* M_ILLAUN */
     { "sparkledream", sp_sparkle, 0 },

--- a/src/spells.h
+++ b/src/spells.h
@@ -44,4 +44,5 @@ int sp_rosthauch(struct castorder *co);
 int sp_sparkle(struct castorder *co);
 int sp_summon_familiar(struct castorder *co);
 
-int sp_summonshadow(struct castorder *co);
+int sp_shadowdemons(struct castorder *co);
+int sp_shadowlords(struct castorder *co);

--- a/src/spells.h
+++ b/src/spells.h
@@ -43,3 +43,5 @@ int sp_destroy_magic(struct castorder *co);
 int sp_rosthauch(struct castorder *co);
 int sp_sparkle(struct castorder *co);
 int sp_summon_familiar(struct castorder *co);
+
+int sp_summonshadow(struct castorder *co);

--- a/src/spells.test.c
+++ b/src/spells.test.c
@@ -304,6 +304,8 @@ static void test_view_reality(CuTest *tc) {
         "unit:unit", "region:region", "command:order", MT_NEW_END);
     mt_create_va(mt_new("viewreality_effect", NULL),
         "unit:unit", MT_NEW_END);
+    mt_create_va(mt_new("summon_effect", NULL),
+        "mage:unit", "amount:int", "race:race", MT_NEW_END);
     mt_create_va(mt_new("summonshadow_effect", NULL),
         "mage:unit", "number:int", MT_NEW_END);
     rx = test_create_region(0, TP_RADIUS + 1, NULL);
@@ -1427,7 +1429,7 @@ static void test_summon_familiar(CuTest *tc) {
     CuAssertPtrEquals(tc, rc_special, (race *)u_race(u2));
 }
 
-static void test_summonshadow(CuTest *tc) {
+static void test_shadowdemons(CuTest *tc) {
     struct region *r;
     struct faction *f;
     unit *u, *u2;
@@ -1445,7 +1447,7 @@ static void test_summonshadow(CuTest *tc) {
     test_set_skill(u, SK_STEALTH, 6, 1);
     test_create_castorder(&co, u, 3, 10., 0, NULL);
 
-    CuAssertIntEquals(tc, co.level, sp_summonshadow(&co));
+    CuAssertIntEquals(tc, co.level, sp_shadowdemons(&co));
     CuAssertPtrNotNull(tc, u2 = u->next);
     CuAssertPtrEquals(tc, u->faction, u2->faction);
     CuAssertPtrEquals(tc, rc, (race *)u_race(u2));
@@ -1453,6 +1455,34 @@ static void test_summonshadow(CuTest *tc) {
     CuAssertIntEquals(tc, 8, effskill(u2, SK_STEALTH, u2->region));
     CuAssertIntEquals(tc, 1, effskill(u2, SK_PERCEPTION, u2->region));
     CuAssertPtrNotNull(tc, test_find_faction_message(f, "summonshadow_effect"));
+}
+
+static void test_shadowlords(CuTest *tc) {
+    struct region *r;
+    struct faction *f;
+    unit *u, *u2;
+    race *rc;
+    castorder co;
+
+    test_setup();
+    r = test_create_plain(0, 0);
+    f = test_create_faction();
+    f->magiegebiet = M_DRAIG;
+    u = test_create_unit(f, r);
+    rc = test_create_race("shadowmaster");
+    CuAssertPtrEquals(tc, (void *)get_race(RC_SHADOWLORD), rc);
+    test_set_skill(u, SK_MAGIC, 10, 1);
+    test_set_skill(u, SK_STEALTH, 6, 1);
+    test_create_castorder(&co, u, 3, 10., 0, NULL);
+
+    CuAssertIntEquals(tc, co.level, sp_shadowlords(&co));
+    CuAssertPtrNotNull(tc, u2 = u->next);
+    CuAssertPtrEquals(tc, u->faction, u2->faction);
+    CuAssertPtrEquals(tc, rc, (race *)u_race(u2));
+    CuAssertIntEquals(tc, 100, u2->number);
+    CuAssertIntEquals(tc, 9, effskill(u2, SK_STEALTH, u2->region));
+    CuAssertIntEquals(tc, 5, effskill(u2, SK_PERCEPTION, u2->region));
+    CuAssertPtrNotNull(tc, test_find_faction_message(f, "summon_effect"));
 }
 
 CuSuite *get_spells_suite(void)
@@ -1494,7 +1524,8 @@ CuSuite *get_spells_suite(void)
     SUITE_ADD_TEST(suite, test_rosthauch);
     SUITE_ADD_TEST(suite, test_sparkle);
     SUITE_ADD_TEST(suite, test_summon_familiar);
-    SUITE_ADD_TEST(suite, test_summonshadow);
+    SUITE_ADD_TEST(suite, test_shadowdemons);
+    SUITE_ADD_TEST(suite, test_shadowlords);
 
     return suite;
 }

--- a/src/spells.test.c
+++ b/src/spells.test.c
@@ -1452,8 +1452,8 @@ static void test_shadowdemons(CuTest *tc) {
     CuAssertPtrEquals(tc, u->faction, u2->faction);
     CuAssertPtrEquals(tc, rc, (race *)u_race(u2));
     CuAssertIntEquals(tc, 100, u2->number);
-    CuAssertIntEquals(tc, 8, effskill(u2, SK_STEALTH, u2->region));
-    CuAssertIntEquals(tc, 1, effskill(u2, SK_PERCEPTION, u2->region));
+    CuAssertIntEquals(tc, 8, get_level(u2, SK_STEALTH));
+    CuAssertIntEquals(tc, 1, get_level(u2, SK_PERCEPTION));
     CuAssertPtrNotNull(tc, test_find_faction_message(f, "summonshadow_effect"));
 }
 
@@ -1480,8 +1480,8 @@ static void test_shadowlords(CuTest *tc) {
     CuAssertPtrEquals(tc, u->faction, u2->faction);
     CuAssertPtrEquals(tc, rc, (race *)u_race(u2));
     CuAssertIntEquals(tc, 100, u2->number);
-    CuAssertIntEquals(tc, 9, effskill(u2, SK_STEALTH, u2->region));
-    CuAssertIntEquals(tc, 5, effskill(u2, SK_PERCEPTION, u2->region));
+    CuAssertIntEquals(tc, 9, get_level(u2, SK_STEALTH));
+    CuAssertIntEquals(tc, 5, get_level(u2, SK_PERCEPTION));
     CuAssertPtrNotNull(tc, test_find_faction_message(f, "summon_effect"));
 }
 

--- a/src/spells.test.c
+++ b/src/spells.test.c
@@ -304,6 +304,8 @@ static void test_view_reality(CuTest *tc) {
         "unit:unit", "region:region", "command:order", MT_NEW_END);
     mt_create_va(mt_new("viewreality_effect", NULL),
         "unit:unit", MT_NEW_END);
+    mt_create_va(mt_new("summonshadow_effect", NULL),
+        "mage:unit", "number:int", MT_NEW_END);
     rx = test_create_region(0, TP_RADIUS + 1, NULL);
     f = test_create_faction();
     u = test_create_unit(f, rx);
@@ -1425,6 +1427,34 @@ static void test_summon_familiar(CuTest *tc) {
     CuAssertPtrEquals(tc, rc_special, (race *)u_race(u2));
 }
 
+static void test_summonshadow(CuTest *tc) {
+    struct region *r;
+    struct faction *f;
+    unit *u, *u2;
+    race *rc;
+    castorder co;
+
+    test_setup();
+    r = test_create_plain(0, 0);
+    f = test_create_faction();
+    f->magiegebiet = M_DRAIG;
+    u = test_create_unit(f, r);
+    rc = test_create_race("shadowdemon");
+    CuAssertPtrEquals(tc, (void *)get_race(RC_SHADOW), rc);
+    test_set_skill(u, SK_MAGIC, 10, 1);
+    test_set_skill(u, SK_STEALTH, 6, 1);
+    test_create_castorder(&co, u, 3, 10., 0, NULL);
+
+    CuAssertIntEquals(tc, co.level, sp_summonshadow(&co));
+    CuAssertPtrNotNull(tc, u2 = u->next);
+    CuAssertPtrEquals(tc, u->faction, u2->faction);
+    CuAssertPtrEquals(tc, rc, (race *)u_race(u2));
+    CuAssertIntEquals(tc, 100, u2->number);
+    CuAssertIntEquals(tc, 8, effskill(u2, SK_STEALTH, u2->region));
+    CuAssertIntEquals(tc, 1, effskill(u2, SK_PERCEPTION, u2->region));
+    CuAssertPtrNotNull(tc, test_find_faction_message(f, "summonshadow_effect"));
+}
+
 CuSuite *get_spells_suite(void)
 {
     CuSuite *suite = CuSuiteNew();
@@ -1464,6 +1494,7 @@ CuSuite *get_spells_suite(void)
     SUITE_ADD_TEST(suite, test_rosthauch);
     SUITE_ADD_TEST(suite, test_sparkle);
     SUITE_ADD_TEST(suite, test_summon_familiar);
+    SUITE_ADD_TEST(suite, test_summonshadow);
 
     return suite;
 }


### PR DESCRIPTION
https://bugs.eressea.de/view.php?id=3011
