### PR TITLE
Bug 3017: Fix message text when movement is blocked

### DIFF
--- a/res/core/messages.xml
+++ b/res/core/messages.xml
@@ -2191,7 +2191,7 @@
       <arg name="target" type="region"/>
     </type>
   </message>
-  <message name="leavefail" section="errors">
+  <message name="enterfail" section="errors">
     <type>
       <arg name="unit" type="unit"/>
       <arg name="region" type="region"/>

--- a/res/translations/messages.de.po
+++ b/res/translations/messages.de.po
@@ -2551,8 +2551,8 @@ msgctxt "curseinfo"
 msgid "maelstrom"
 msgstr "Der Mahlstrom in dieser Region wird alle Schiffe, die in seinen Sog geraten, schwer beschädigen. ($int36($id))"
 
-msgid "leavefail"
-msgstr "\"$unit($unit) konnte aus $region($region) nicht ausreisen.\""
+msgid "enterfail"
+msgstr "\"$unit($unit) konnte nach $region($region) nicht einreisen.\""
 
 msgid "reduced_production"
 msgstr "Die Region ist verwüstet, der Boden karg."

--- a/res/translations/messages.en.po
+++ b/res/translations/messages.en.po
@@ -2551,8 +2551,8 @@ msgctxt "curseinfo"
 msgid "maelstrom"
 msgstr "The maelstrom in this area will heavily damage all ships coming into its wake. ($int36($id))"
 
-msgid "leavefail"
-msgstr "\"$unit($unit) could not leave $region($region).\""
+msgid "enterfail"
+msgstr "\"$unit($unit) could not enter $region($region).\""
 
 msgid "reduced_production"
 msgstr "The region is ravaged, the ground infertile."

--- a/src/move.c
+++ b/src/move.c
@@ -1103,14 +1103,14 @@ bool move_blocked(const unit * u, const region * r, const region * r2)
         }
         b = b->next;
     }
-
+#ifdef ENABLE_FOGTRAP_CURSE
     if (r->attribs) {
         curse *c = get_curse(r->attribs, &ct_fogtrap);
         if (curse_active(c)) {
             return true;
         }
     }
-
+#endif
     if (r2->attribs && fval(u_race(u), RCF_UNDEAD)) {
         curse *c = get_curse(r2->attribs, &ct_holyground);
         return curse_active(c);
@@ -1657,9 +1657,9 @@ static const region_list *travel_route(unit * u, const capacities *cap,
 
         }
 
-        /* movement blocked by a wall */
+        /* movement blocked by a wall or curse */
         if (reldir >= 0 && move_blocked(u, current, next)) {
-            ADDMSG(&u->faction->msgs, msg_message("leavefail",
+            ADDMSG(&u->faction->msgs, msg_message("enterfail",
                 "unit region", u, next));
             break;
         }

--- a/src/move.test.c
+++ b/src/move.test.c
@@ -1362,6 +1362,7 @@ static void test_holyground_blocks_undead_moves(CuTest* tc) {
     region* r, *rt;
     struct locale* lang;
     race* rc;
+    message* msg;
 
     test_setup();
     setup_move();
@@ -1380,7 +1381,9 @@ static void test_holyground_blocks_undead_moves(CuTest* tc) {
     move_cmd(u, u->thisorder);
     CuAssertPtrEquals(tc, NULL, u->thisorder);
     CuAssertPtrEquals(tc, NULL, test_find_messagetype(u->faction->msgs, "enterfail"));
-    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "moveblocked"));
+    CuAssertPtrNotNull(tc, msg = test_find_messagetype(u->faction->msgs, "moveblocked"));
+    CuAssertPtrEquals(tc, u, msg->parameters[0].v);
+    CuAssertIntEquals(tc, D_WEST, msg->parameters[1].i);
     CuAssertPtrEquals(tc, r, u->region);
     test_teardown();
 }
@@ -1390,6 +1393,7 @@ static void test_holyground_blocks_undead_follow(CuTest* tc) {
     region* r, *rt;
     struct locale* lang;
     race* rc;
+    message* msg;
 
     test_setup();
     setup_move();
@@ -1419,7 +1423,9 @@ static void test_holyground_blocks_undead_follow(CuTest* tc) {
     CuAssertPtrEquals(tc, NULL, test_find_messagetype(u2->faction->msgs, "enterfail"));
     CuAssertPtrEquals(tc, NULL, test_find_messagetype(u2->faction->msgs, "moveblocked"));
     CuAssertPtrEquals(tc, NULL, test_find_messagetype(u->faction->msgs, "moveblocked"));
-    CuAssertPtrNotNull(tc, test_find_messagetype(u->faction->msgs, "enterfail"));
+    CuAssertPtrNotNull(tc, msg = test_find_messagetype(u->faction->msgs, "enterfail"));
+    CuAssertPtrEquals(tc, u, msg->parameters[0].v);
+    CuAssertPtrEquals(tc, rt, msg->parameters[1].v);
     test_teardown();
 }
 


### PR DESCRIPTION
https://bugs.eressea.de/view.php?id=3017
Add some tests for the holyground effect.