### PR TITLE
Magic resistance bonus of elven bows correctly implemented

### DIFF
--- a/res/core/weapons/greatbow.xml
+++ b/res/core/weapons/greatbow.xml
@@ -7,7 +7,7 @@
     <construction skill="weaponsmithing" minskill="5">
       <requirement type="mallorn" quantity="2"/>
     </construction>
-    <weapon pierce="true" missile="true" skill="bow" offmod="0" defmod="0" reload="0" magres="0.0">
+    <weapon pierce="true" missile="true" skill="bow" offmod="0" defmod="0" reload="0" magres="0.15">
       <damage type="rider" value="2d6+4"/>
       <damage type="footman" value="2d6+4"/>
       <modifier type="missile_target" value="2"/>


### PR DESCRIPTION
Mallorn weapons give a 15% bonus to magic resistance, this is correctly implemented for all Mallorn weapons except elven bows

https://wiki.eressea.de/index.php/Kriegstabellen

"Alle Mallornwaffen erhöhen die Magieresistenz um 15%, alle Laenwaffen und -rüstungen um 30%."