### PR TITLE
Meldung über Heiltrank ging an die falsche Einheit

### DIFF
--- a/src/battle.c
+++ b/src/battle.c
@@ -1127,8 +1127,8 @@ static void demon_dazzle(fighter *af, troop dt) {
 }
 
 static bool survives(fighter *af, troop dt, battle *b) {
-    const unit *du = af->unit;
     const fighter *df = dt.fighter;
+    const unit* du = df->unit;
 
     if (df->person[dt.index].hp > 0) {    /* Hat ueberlebt */
         demon_dazzle(af, dt);


### PR DESCRIPTION
https://bugs.eressea.de/view.php?id=3024