### PR TITLE
Bug 3032: Rostige Waffen kann man nicht bauen

### DIFF
--- a/res/core/weapons/rustyaxe.xml
+++ b/res/core/weapons/rustyaxe.xml
@@ -3,7 +3,7 @@
 <resources>
 <resource name="rustyaxe">
   <item weight="200">
-    <construction skill="weaponsmithing" minskill="3">
+    <construction skill="weaponsmithing">
       <requirement type="log" quantity="1"/>
       <requirement type="iron" quantity="1"/>
     </construction>

--- a/res/core/weapons/rustygreatsword.xml
+++ b/res/core/weapons/rustygreatsword.xml
@@ -3,7 +3,7 @@
 <resources>
 <resource name="rustygreatsword">
   <item weight="200" score="20">
-    <construction skill="weaponsmithing" minskill="4">
+    <construction skill="weaponsmithing">
       <requirement type="iron" quantity="2"/>
     </construction>
     <weapon cut="true" skill="melee" offmod="-2" defmod="-3">

--- a/res/core/weapons/rustyhalberd.xml
+++ b/res/core/weapons/rustyhalberd.xml
@@ -3,7 +3,7 @@
 <resources>
 <resource name="rustyhalberd">
   <item weight="200" score="20">
-    <construction skill="weaponsmithing" minskill="3">
+    <construction skill="weaponsmithing">
       <requirement type="iron" quantity="1"/>
       <requirement type="log" quantity="2"/>
     </construction>

--- a/res/core/weapons/rustysword.xml
+++ b/res/core/weapons/rustysword.xml
@@ -3,7 +3,7 @@
 <resources>
 <resource name="rustysword">
   <item weight="100" score="10">
-    <construction skill="weaponsmithing" minskill="3">
+    <construction skill="weaponsmithing">
       <requirement type="iron" quantity="1"/>
     </construction>
     <weapon cut="true" skill="melee" offmod="-1" defmod="-1">

--- a/res/e3a/weapons.xml
+++ b/res/e3a/weapons.xml
@@ -6,7 +6,7 @@
   1. you cannot use this with cavalry
 -->
   <item weight="200" score="20" deny="goblin">
-    <construction skill="weaponsmithing" minskill="4">
+    <construction skill="weaponsmithing">
       <requirement type="iron" quantity="2"/>
     </construction>
     <weapon useshield="false" cut="true" skill="melee" offmod="-2" defmod="-3" horse="false">
@@ -20,7 +20,7 @@
   1. you cannot use this with cavalry
 -->
   <item weight="200" score="20" deny="goblin">
-    <construction skill="weaponsmithing" minskill="3">
+    <construction skill="weaponsmithing">
       <requirement type="iron" quantity="1"/>
       <requirement type="log" quantity="1"/>
     </construction>

--- a/scripts/tests/e2/production.lua
+++ b/scripts/tests/e2/production.lua
@@ -216,3 +216,29 @@ function test_smithy_bonus_mixed()
 
     turn_end()
 end
+
+function test_produce_rusty_weapon()
+    local r = region.create(0, 0, 'mountain')
+    local f = faction.create('human')
+    local u = unit.create(f, r, 1)
+
+    u:set_skill('weaponsmithing', 5)
+    u:add_item('iron', 100)
+    u:set_orders("MACHE 1 Schartiges~Schwert")
+    turn_process()
+    assert_equal(0, u:get_item('rustysword'))
+    assert_equal(1, u.faction:count_msg_type("error_cannotmake"))
+end
+
+function test_produce_rusty_armor()
+    local r = region.create(0, 0, 'mountain')
+    local f = faction.create('human')
+    local u = unit.create(f, r, 1)
+
+    u:set_skill('armorer', 5)
+    u:add_item('iron', 100)
+    u:set_orders("MACHE 1 Rostiger~Plattenpanzer")
+    turn_process()
+    assert_equal(0, u:get_item('rustyplate'))
+    assert_equal(1, u.faction:count_msg_type("error_cannotmake"))
+end

--- a/src/economy.c
+++ b/src/economy.c
@@ -1054,7 +1054,7 @@ void make_item(unit * u, const item_type * itype, int want)
         if (itype->flags & ITF_POTION) {
             create_potion(u, itype, want);
         }
-        else if (itype->construction && itype->construction->materials) {
+        else if (itype->construction && itype->construction->materials && itype->construction->minskill > 0) {
             manufacture(u, itype, want);
         }
         else {

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1903,6 +1903,38 @@ static void test_repopulate(CuTest* tc)
     test_teardown();
 }
 
+static void test_repopulate_blocked(CuTest* tc)
+{
+    terrain_type* ter;
+    region* r;
+    unit* u;
+    const race* rc;
+
+    test_setup();
+    rc = test_create_race("demon");
+    CuAssertPtrEquals(tc, (void*)rc, (void*)get_race(RC_DAEMON));
+    ter = test_create_terrain("test", LAND_REGION);
+    ter->size = 10000;
+
+    r = test_create_region(0, 0, ter);
+    rsettrees(r, 1, 0);
+    rsettrees(r, 2, 0);
+
+    u = test_create_unit(test_create_faction(), r);
+    random_source_inject_constant(1.0F); /* max. unlucky dice rolls */
+
+    rsetpeasants(r, 0); /* default limit is 90 */
+    immigration();
+    CuAssertIntEquals(tc, 2, rpeasants(r));
+
+    u_setrace(u, rc); /* demons prevent repopulation */
+    rsetpeasants(r, 0); /* default limit is 90 */
+    immigration();
+    CuAssertIntEquals(tc, 0, rpeasants(r));
+
+    test_teardown();
+}
+
 static void test_repopulate_income_based(CuTest* tc)
 {
     terrain_type* ter;
@@ -2886,6 +2918,7 @@ CuSuite *get_laws_suite(void)
     SUITE_ADD_TEST(suite, test_immigration);
     SUITE_ADD_TEST(suite, test_repopulate);
     SUITE_ADD_TEST(suite, test_repopulate_income_based);
+    SUITE_ADD_TEST(suite, test_repopulate_blocked);
     SUITE_ADD_TEST(suite, test_demon_hunger);
     SUITE_ADD_TEST(suite, test_armedmen);
     SUITE_ADD_TEST(suite, test_cansee);

--- a/src/spells/combatspells.c
+++ b/src/spells/combatspells.c
@@ -285,7 +285,7 @@ int sp_combatrosthauch(struct castorder * co)
         size_t len = arrlen(df->weapons);
 
         for (w = 0; w != len; ++w) {
-            weapon *wp = df->weapons;
+            weapon *wp = df->weapons + w;
             if (df->unit->items && force > 0) {
                 const item_type *itype = wp->item.type;
                 item ** itp = i_find(&df->unit->items, itype);


### PR DESCRIPTION
Neue Regel: Wenn ein Gegenstand kein Mindestbautalent hat, kann man ihn nicht produzieren.