### PR TITLE
remove double book-keeping of building_type objects

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -598,16 +598,25 @@ static int config_get_ships(lua_State * L)
     return 1;
 }
 
+struct settable_data {
+    lua_State *L;
+    int index;
+};
+
+static int push_building_cb(building_type *btype, void *udata)
+{
+    struct settable_data *capture = (struct settable_data *)udata;
+    lua_State *L = capture->L;
+    tolua_pushstring(L, btype->_name);
+    lua_rawseti(L, -2, ++capture->index);
+    return 0;
+}
+
 static int config_get_buildings(lua_State * L)
 {
-    selist *ql;
-    int qi, i = 0;
-    lua_createtable(L, selist_length(buildingtypes), 0);
-    for (qi = 0, ql = buildingtypes; ql; selist_advance(&ql, &qi, 1)) {
-        building_type *btype = (building_type *)selist_get(ql, qi);
-        tolua_pushstring(L, btype->_name);
-        lua_rawseti(L, -2, ++i);
-    }
+    struct settable_data capture = { L, 0 };
+    lua_newtable(L);
+    bt_foreach(push_building_cb, &capture);
     return 1;
 }
 

--- a/src/jsonconf.test.c
+++ b/src/jsonconf.test.c
@@ -371,6 +371,11 @@ static void test_ships(CuTest * tc)
     test_teardown();
 }
 
+static int has_btypes_cb(building_type *btype, void *udata)
+{
+    return 1;
+}
+
 static void test_castles(CuTest *tc) {
     const char * data = "{\"buildings\": { \"castle\" : { "
         "\"stages\" : ["
@@ -386,13 +391,13 @@ static void test_castles(CuTest *tc) {
     test_setup();
 
     CuAssertPtrNotNull(tc, json);
-    CuAssertPtrEquals(tc, NULL, buildingtypes);
+    CuAssertIntEquals(tc, 0, bt_foreach(has_btypes_cb, NULL));
+
     json_config(json);
 
     bt = bt_find("castle");
     CuAssertPtrNotNull(tc, bt);
     CuAssertIntEquals(tc, 3, (int)arrlen(bt->a_stages));
-    CuAssertPtrNotNull(tc, buildingtypes);
 
     stage = bt->a_stages;
     CuAssertStrEquals(tc, "site", stage->name);
@@ -465,10 +470,9 @@ static void test_buildings(CuTest * tc)
     test_setup();
 
     CuAssertPtrNotNull(tc, json);
-    CuAssertPtrEquals(tc, NULL, buildingtypes);
+    CuAssertPtrEquals(tc, NULL, (void *)bt_find("shed"));
     json_config(json);
 
-    CuAssertPtrNotNull(tc, buildingtypes);
     bt = bt_find("shed");
     CuAssertPtrNotNull(tc, bt);
     CuAssertPtrNotNull(tc, bt->maintenance);
@@ -559,7 +563,7 @@ static void test_ships_default(CuTest * tc)
     test_teardown();
 }
 
-static void test_configs(CuTest * tc)
+static void test_includes(CuTest * tc)
 {
     const char * data = "{\"include\": [ \"test.json\" ] }";
     FILE *F;
@@ -572,9 +576,9 @@ static void test_configs(CuTest * tc)
     fwrite(building_data, 1, strlen(building_data), F);
     fclose(F);
     CuAssertPtrNotNull(tc, json);
-    CuAssertPtrEquals(tc, NULL, buildingtypes);
+    CuAssertPtrEquals(tc, NULL, (void *) bt_find("house"));
     json_config(json);
-    CuAssertPtrNotNull(tc, buildingtypes);
+    CuAssertPtrNotNull(tc, bt_find("house"));
     if (remove("test.json")!=0 && errno==ENOENT) {
         errno = 0;
     }
@@ -773,7 +777,7 @@ CuSuite *get_jsonconf_suite(void)
     SUITE_ADD_TEST(suite, test_ships);
     SUITE_ADD_TEST(suite, test_buildings);
     SUITE_ADD_TEST(suite, test_buildings_default);
-    SUITE_ADD_TEST(suite, test_configs);
+    SUITE_ADD_TEST(suite, test_includes);
     SUITE_ADD_TEST(suite, test_castles);
     SUITE_ADD_TEST(suite, test_terrains);
     SUITE_ADD_TEST(suite, test_races);

--- a/src/kernel/building.h
+++ b/src/kernel/building.h
@@ -63,7 +63,6 @@ extern "C" {
         struct building_stage *a_stages;
     } building_type;
 
-    extern struct selist *buildingtypes;
     extern struct attrib_type at_building_generic_type;
 
     int cmp_castle_size(const struct building *b, const struct building *a);
@@ -72,7 +71,7 @@ extern "C" {
     bool bt_changed(int *cache);
     const building_type *bt_find(const char *name);
     void free_buildingtypes(void);
-
+    int bt_foreach(int (*callback)(struct building_type *, void *), void *udata);
     bool in_safe_building(struct unit *u1, struct unit *u2);
 
 #define BFL_NONE           0x00

--- a/src/reports.h
+++ b/src/reports.h
@@ -56,7 +56,7 @@ extern "C" {
 
     typedef struct report_context {
         struct faction *f;
-        struct selist *addresses;
+        struct selist *addresses; /* used as a set<faction *> */
         struct region *first, *last;
         void *userdata;
         time_t report_time;

--- a/src/spells.h
+++ b/src/spells.h
@@ -46,3 +46,4 @@ int sp_summon_familiar(struct castorder *co);
 
 int sp_shadowdemons(struct castorder *co);
 int sp_shadowlords(struct castorder *co);
+int sp_analysemagic(struct castorder *co);

--- a/src/spells.test.c
+++ b/src/spells.test.c
@@ -1407,6 +1407,7 @@ static void test_summon_familiar(CuTest *tc) {
     CuAssertTrue(tc, is_familiar(u2));
     CuAssertPtrEquals(tc, u, get_familiar_mage(u2));
     CuAssertPtrEquals(tc, rc_special, (race *)u_race(u2));
+    test_teardown();
 }
 
 static void test_shadowdemons(CuTest *tc) {
@@ -1435,6 +1436,7 @@ static void test_shadowdemons(CuTest *tc) {
     CuAssertIntEquals(tc, 8, get_level(u2, SK_STEALTH));
     CuAssertIntEquals(tc, 1, get_level(u2, SK_PERCEPTION));
     CuAssertPtrNotNull(tc, test_find_faction_message(f, "summonshadow_effect"));
+    test_teardown();
 }
 
 static void test_shadowlords(CuTest *tc) {
@@ -1463,6 +1465,30 @@ static void test_shadowlords(CuTest *tc) {
     CuAssertIntEquals(tc, 9, get_level(u2, SK_STEALTH));
     CuAssertIntEquals(tc, 5, get_level(u2, SK_PERCEPTION));
     CuAssertPtrNotNull(tc, test_find_faction_message(f, "summon_effect"));
+    test_teardown();
+}
+
+static void test_analysemagic(CuTest *tc) {
+    struct region *r;
+    struct faction *f;
+    unit *u, *u2;
+    castorder co;
+    spellparameter param, *args = NULL;
+
+    test_setup();
+    r = test_create_plain(0, 0);
+    f = test_create_faction();
+    f->magiegebiet = M_DRAIG;
+    u = test_create_unit(f, r);
+    u2 = test_create_unit(f, r);
+
+    param.flag = 0;
+    param.typ = SPP_UNIT;
+    param.data.u = u2;
+    arrput(args, param);
+    test_create_castorder(&co, u, 3, 10., 0, args);
+    CuAssertIntEquals(tc, co.level, sp_analysemagic(&co));
+    test_teardown();
 }
 
 CuSuite *get_spells_suite(void)
@@ -1506,6 +1532,7 @@ CuSuite *get_spells_suite(void)
     SUITE_ADD_TEST(suite, test_summon_familiar);
     SUITE_ADD_TEST(suite, test_shadowdemons);
     SUITE_ADD_TEST(suite, test_shadowlords);
+    SUITE_ADD_TEST(suite, test_analysemagic);
 
     return suite;
 }


### PR DESCRIPTION
we didn't need the global buildingtypes list