### PR TITLE
Bug 3076: init_reports must run before write_game

### DIFF
--- a/scripts/run-turn.lua
+++ b/scripts/run-turn.lua
@@ -151,6 +151,7 @@ function process(rules, orders)
   turn_end() -- ageing, etc.
 
   if not config.debug then
+      init_reports()
       file = '' .. get_turn() .. '.dat'
       if eressea.write_game(file)~=0 then
         eressea.log.error("could not write game")


### PR DESCRIPTION
https://bugs.eressea.de/view.php?id=3076
ship owners have to be sorted to the top of the list