### PR TITLE
Add clangd cache folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tests/config.lua
 /.idea/
 .env*
 /tests/data/test.dat
+.cache/clangd


### PR DESCRIPTION
clangd is a common LSP server for c/c++. But it stores a lot of cache files under .cache/clangd. Lets gitignore those.