### PR TITLE
No NMR dropout warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -336,7 +336,6 @@ target_link_libraries(test_eressea
   game
   cutest
   ${LUA_LIBRARIES}
-  ${CLIBS_LIBRARIES}
   ${STORAGE_LIBRARIES}
   ${CJSON_LIBRARY}
   ${INIPARSER_LIBRARY}

--- a/src/laws.c
+++ b/src/laws.c
@@ -770,14 +770,16 @@ void immigration(void)
     }
 }
 
+#define HELP_NMR (HELP_GUARD|HELP_MONEY)
+
 void nmr_warnings(void)
 {
     faction *f, *fa;
-#define HELP_NMR (HELP_GUARD|HELP_MONEY)
+    int timeout = NMRTimeout();
     for (f = factions; f; f = f->next) {
         if (!fval(f, FFL_NOIDLEOUT|FFL_PAUSED) && turn > f->lastorders) {
             ADDMSG(&f->msgs, msg_message("nmr_warning", ""));
-            if (turn - f->lastorders == NMRTimeout() - 1) {
+            if (turn - f->lastorders == timeout - 1) {
                 ADDMSG(&f->msgs, msg_message("nmr_warning_final", ""));
             }
             if ((turn - f->lastorders) >= 2) {
@@ -792,7 +794,7 @@ void nmr_warnings(void)
                     else if (alliedfaction(f, fa, HELP_NMR) && alliedfaction(fa, f, HELP_NMR)) {
                         warn = 1;
                     }
-                    if (warn) {
+                    if (warn && turn - f->lastorders < timeout) {
                         if (msg == NULL) {
                             msg = msg_message("warn_dropout", "faction turns", f,
                                     turn - f->lastorders);

--- a/src/laws.test.c
+++ b/src/laws.test.c
@@ -1644,13 +1644,24 @@ static void test_nmr_warnings(CuTest *tc) {
     faction_set_age(f2, 2);
     CuAssertIntEquals(tc, 2, faction_age(f2));
     f2->lastorders = 1;
+    ally_set(&f1->allies, f2, HELP_GUARD);
+    ally_set(&f2->allies, f1, HELP_GUARD);
     nmr_warnings();
     CuAssertPtrNotNull(tc, f1->msgs);
     CuAssertPtrNotNull(tc, test_find_messagetype(f1->msgs, "nmr_warning"));
+    CuAssertPtrNotNull(tc, test_find_messagetype(f1->msgs, "warn_dropout"));
     CuAssertPtrNotNull(tc, f2->msgs);
     CuAssertPtrNotNull(tc, f2->msgs->begin);
     CuAssertPtrNotNull(tc, test_find_messagetype(f2->msgs, "nmr_warning"));
     CuAssertPtrNotNull(tc, test_find_messagetype(f2->msgs, "nmr_warning_final"));
+    test_clear_messages(f1);
+    test_clear_messages(f2);
+    f2->lastorders = 0;
+    nmr_warnings();
+    CuAssertPtrNotNull(tc, f1->msgs);
+    CuAssertPtrNotNull(tc, test_find_messagetype(f1->msgs, "nmr_warning"));
+    CuAssertPtrEquals(tc, NULL, test_find_messagetype(f1->msgs, "warn_dropout"));
+
     test_teardown();
 }
 


### PR DESCRIPTION
No NMR dropout warning to allies when the faction has maxed out NMR and dies.